### PR TITLE
release: v1.3.1 — tool-continuation and durability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.3.1] - 2026-07-25
+
+### Fixed
+
+- **Tool continuation was unrecoverable after the first tool round.** Losing the upstream bridge mid-tool failed with `Cursor tool continuation was lost … skipReason=pending_tool_call_mismatch` on every round after the first. The mid-pause snapshot records only the round that was parked, but the client re-sends every tool result in the in-flight user turn, and recovery demanded the two sets be equal. The parked set must instead be _covered by_ what arrived; the in-flight turn is still matched exactly, which is what pins the replayed transcript to the client's view.
+- **Parallel tool calls beyond the first never reached the client.** Cursor can frame several execs in one chunk, but the response was closed on the first, so the rest were silently dropped and only re-offered if the bridge happened to survive. The pause is now deferred to the end of the chunk. Only execs the client was actually told about are recorded as pending, since recovery can only expect back what the client saw.
+- **Checkpoints delivered during a tool pause were discarded.** The latest checkpoint was held in per-round state while the bridge outlived the round, so anything arriving mid-pause was stranded in the previous round's closure — a recurring cause of `hadStoredCheckpoint=false` diagnostics. It now lives on the bridge.
+- **An oversized or unsupported image broke every later turn.** The whole history is re-parsed on each request and an image failing Cursor's 5 MiB / format check threw, so one bad screenshot — typically from a tool result — permanently failed the conversation. Images already in the transcript are now decoded leniently; the message being sent still errors, since that one the caller can fix.
+- **An undecodable checkpoint was never discarded**, failing every subsequent turn in the conversation. It is now decoded once during staleness validation and dropped on failure, degrading to a rebuild.
+- **The most load-bearing blob was first to be evicted.** `trimBlobStore` drops oldest-first, but merging used `Map.set`, which leaves an existing key at its original position — so the system-prompt blob, written first on every build and referenced by every checkpoint, was permanently the oldest entry. Merging now re-inserts, making eviction genuinely least-recently-referenced.
+- **Tool-result images were dropped on checkpoint recovery**, though the full-history rebuild path preserved them.
+- Tool results with no `tool_call_id` are excluded from recovery's set matching instead of reading as duplicates and failing an otherwise sound recovery.
+- A live bridge is no longer resumed when the request's history does not match the one it was parked on. Without a Pi session id the bridge key is only a hash of the opening user message, so two conversations that start alike shared a key.
+
 ## [1.3.0] - 2026-07-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rahularya01/pi-cursor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rahularya01/pi-cursor",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rahularya01/pi-cursor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Native Cursor provider for Pi Coding Agent (OAuth + Connect/protobuf streamSimple)",
   "author": "Rahul Arya",
   "license": "MIT",

--- a/src/stream/images.ts
+++ b/src/stream/images.ts
@@ -22,6 +22,15 @@ export const CURSOR_SUPPORTED_IMAGE_MIME_TYPES = new Set([
 
 export interface ImageDecodeOptions {
   enforceCursorCliLimits?: boolean;
+  /**
+   * Return `undefined` instead of throwing when an image fails Cursor's limits.
+   *
+   * Rejecting loudly is right for the image a caller is attaching right now — they can resize it.
+   * It is wrong for images already sitting in the transcript: those are unfixable, and since the
+   * whole history is re-parsed on every request, one bad image would otherwise fail not just its
+   * own turn but every turn after it, permanently.
+   */
+  dropInvalid?: boolean;
 }
 
 export function normalizeImageMimeType(mimeType: string): string {
@@ -81,15 +90,35 @@ export function decodeBase64Image(
   if (!base64) return undefined;
   const bytes = new Uint8Array(Buffer.from(base64, "base64"));
   if (bytes.length === 0) return undefined;
-  const finalMimeType = options.enforceCursorCliLimits
-    ? validateCursorCliImageLimits(bytes)
-    : normalizedMimeType;
+  let finalMimeType = normalizedMimeType;
+  if (options.enforceCursorCliLimits) {
+    try {
+      finalMimeType = validateCursorCliImageLimits(bytes);
+    } catch (error) {
+      if (!options.dropInvalid) throw error;
+      return undefined;
+    }
+  }
   return { data: bytes, mimeType: finalMimeType };
 }
 
 export function parseImageDataUrl(
   url: string,
   options: ImageDecodeOptions = {},
+): ParsedImageContent | undefined {
+  if (options.dropInvalid) {
+    try {
+      return parseImageDataUrlStrict(url, options);
+    } catch {
+      return undefined;
+    }
+  }
+  return parseImageDataUrlStrict(url, options);
+}
+
+function parseImageDataUrlStrict(
+  url: string,
+  options: ImageDecodeOptions,
 ): ParsedImageContent | undefined {
   const trimmed = url.trim();
   if (/^https?:\/\//i.test(trimmed)) {

--- a/src/stream/message-parsing.ts
+++ b/src/stream/message-parsing.ts
@@ -78,7 +78,10 @@ export function parseToolResultImagePayloads(
     if (!payload?.toolCallId || !Array.isArray(payload.images)) continue;
     const images = payload.images
       .map((image) =>
-        decodeBase64Image(image.data, image.mimeType, { enforceCursorCliLimits: true }),
+        decodeBase64Image(image.data, image.mimeType, {
+          enforceCursorCliLimits: true,
+          dropInvalid: true,
+        }),
       )
       .filter((image): image is ParsedImageContent => !!image);
     if (images.length === 0) continue;
@@ -246,6 +249,17 @@ export function parseMessages(
   if (systemParts.length > 0) systemPrompt = systemParts.join("\n");
 
   const nonSystem = messages.filter((m) => m.role !== "system");
+  // Only the newest user message is one the caller can still fix, so it is the only place an
+  // unusable image is worth failing the request over. Everything older is decoded leniently — see
+  // ImageDecodeOptions.dropInvalid.
+  const liveUserIndex = nonSystem.reduce(
+    (last, msg, index) => (msg.role === "user" ? index : last),
+    -1,
+  );
+  const decodeOptions = (index: number): ImageDecodeOptions => ({
+    enforceCursorCliLimits: true,
+    dropInvalid: index !== liveUserIndex,
+  });
   let currentTurn:
     | (ParsedTurn & {
         toolCallById: Map<string, ParsedToolCallStep>;
@@ -260,15 +274,17 @@ export function parseMessages(
     currentTurn = null;
   };
 
-  for (const msg of nonSystem) {
+  for (const [index, msg] of nonSystem.entries()) {
     if (currentTurn && isSyntheticToolResultImageMessage(msg)) {
       const hasMetadataImages = currentTurn.steps.some(
         (step) => step.kind === "toolCall" && step.result?.images?.length,
       );
       if (!hasMetadataImages) {
+        // Tool output, not something the caller attached — always lenient, even when this
+        // synthetic message happens to be the last user-role entry.
         attachSyntheticToolResultImages(
           currentTurn,
-          imageContent(msg.content, { enforceCursorCliLimits: true }),
+          imageContent(msg.content, { enforceCursorCliLimits: true, dropInvalid: true }),
         );
       }
       continue;
@@ -276,7 +292,7 @@ export function parseMessages(
 
     if (msg.role === "user") {
       finalizeCurrentTurn();
-      const userImages = imageContent(msg.content, { enforceCursorCliLimits: true });
+      const userImages = imageContent(msg.content, decodeOptions(index));
       currentTurn = {
         userText: textContent(msg.content),
         steps: [],
@@ -312,7 +328,7 @@ export function parseMessages(
 
     if (msg.role === "tool") {
       const toolCallId = msg.tool_call_id ?? "";
-      const inlineImages = imageContent(msg.content, { enforceCursorCliLimits: true });
+      const inlineImages = imageContent(msg.content, decodeOptions(index));
       const images = mergeImages(inlineImages, toolResultImagesById.get(toolCallId));
       const content = normalizeToolResultText(textContent(msg.content), images);
       const isError = msg.is_error === true;

--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -182,6 +182,7 @@ export { getCursorAgentUrl } from "./config.js";
 import type {
   ActiveBridge,
   ChatCompletionRequest,
+  CheckpointRef,
   CursorNativeStreamConfig,
   CursorNativeStreamOptions,
   IdleRestartContext,
@@ -589,7 +590,29 @@ async function handleCursorNativeRequest(
     );
     if (activeBridge) {
       removeActiveBridge(bridgeKey);
-      if (activeBridge.bridge.alive) {
+      // Without a Pi session id the bridge key is only a hash of the opening user message, so two
+      // conversations that start alike land on the same key. Resuming the wrong bridge would splice
+      // one conversation's tool results into another; the history fingerprint is what tells them
+      // apart. Recovery already fingerprints — this closes the same hole on the live path.
+      //
+      // Scoped to sessionless keys on purpose. A session-derived key cannot collide, so there the
+      // check could only ever produce false negatives — tearing down a healthy bridge if the client
+      // reshapes its history mid-turn — with no collision to protect against.
+      const currentHistoryFingerprint = fingerprintCompletedTurns(turns);
+      const historyMatches =
+        !!sessionId || activeBridge.historyFingerprint === currentHistoryFingerprint;
+      if (!historyMatches) {
+        debugLog("bridge.active_history_mismatch", {
+          requestId,
+          bridgeKey,
+          bridgeKeyPrefix: bridgeKeyPrefix(bridgeKey),
+          convKey,
+          storedFingerprint: activeBridge.historyFingerprint,
+          currentFingerprint: currentHistoryFingerprint,
+        });
+        setLastStreamEvent("active_bridge_history_mismatch");
+      }
+      if (activeBridge.bridge.alive && historyMatches) {
         handleNativeToolResultResume(
           activeBridge,
           toolResults,
@@ -636,14 +659,19 @@ async function handleCursorNativeRequest(
         pendingToolCallIds: toolResults.map((r) => r.toolCallId),
       });
       const mcpTools = buildMcpToolDefinitions(toolResolution.tools);
+      // Images ride the recovered user turn on this path too — dropping them here silently lost
+      // screenshots that the rebuild path preserves.
+      const recoveredUserImages = collectToolResultImages(toolResults);
       const recoveredCurrentTurn: ParsedTurn = {
         userText: decision.wrappedText,
         steps: [],
+        ...(recoveredUserImages.length ? { userImages: recoveredUserImages } : {}),
       };
       const payload = buildCursorRequest({
         modelId,
         systemPrompt,
         userText: decision.wrappedText,
+        userImages: recoveredUserImages,
         turns,
         conversationId: decision.conversationId,
         checkpoint: decision.checkpoint,
@@ -841,6 +869,7 @@ function writeNativeStream(
   requestId?: string,
   idleRetry?: StreamIdleRetryController,
   streamIdleTimeoutMs = resolveStreamIdleTimeoutMs(process.env.PI_CURSOR_STREAM_IDLE_TIMEOUT_MS),
+  checkpointRef: CheckpointRef = { current: null },
 ): void {
   debugLog("native.stream.start", {
     requestId,
@@ -867,8 +896,17 @@ function writeNativeStream(
   let mcpExecReceived = false;
   let cancelled = false;
   let streamError: Error | null = null;
-  let latestCheckpoint: Uint8Array | null = null;
   let emittedUserVisibleContent = false;
+  // Only execs the client was actually told about may be recorded as pending: recovery matches the
+  // snapshot against the tool results the client sends back, and it can only send back what it saw.
+  const emittedExecs: PendingExec[] = [];
+  // Cursor can emit several execs in one chunk. Closing the writer on the first would hide the
+  // rest, so the pause is deferred until the whole chunk has been parsed.
+  let pauseRequested = false;
+  let cachedHistoryFingerprint: string | undefined;
+  // Completed turns are fixed for the life of a stream, so this is hashed at most once.
+  const historyFingerprint = () =>
+    (cachedHistoryFingerprint ??= fingerprintCompletedTurns(completedTurns));
   const idleWatchdog = createStreamIdleWatchdog({
     timeoutMs: streamIdleTimeoutMs,
     onTimeout: () => {
@@ -879,7 +917,7 @@ function writeNativeStream(
       const maxRetries = idleRetry?.maxRetries ?? 0;
       const restartContext: IdleRestartContext = {
         emittedUserVisibleContent,
-        latestCheckpoint,
+        latestCheckpoint: checkpointRef.current,
         blobStore,
         completedTurns,
         currentTurn,
@@ -893,7 +931,7 @@ function writeNativeStream(
         attempt,
         maxRetries,
         emittedUserVisibleContent,
-        hasCheckpoint: !!latestCheckpoint,
+        hasCheckpoint: !!checkpointRef.current,
       });
       setLastIdleTimeout({
         timeoutMs: streamIdleTimeoutMs,
@@ -902,7 +940,7 @@ function writeNativeStream(
       });
       persistAbortedConversationState(
         convKey,
-        latestCheckpoint,
+        checkpointRef.current,
         blobStore,
         completedTurns,
         currentTurn,
@@ -985,7 +1023,7 @@ function writeNativeStream(
     cancelled = true;
     persistAbortedConversationState(
       convKey,
-      latestCheckpoint,
+      checkpointRef.current,
       blobStore,
       completedTurns,
       currentTurn,
@@ -994,7 +1032,7 @@ function writeNativeStream(
       requestId,
       bridgeKey,
       convKey,
-      hasCheckpoint: !!latestCheckpoint,
+      hasCheckpoint: !!checkpointRef.current,
     });
     idleWatchdog.clear();
     cleanupBridge(bridge, heartbeatTimer, bridgeKey);
@@ -1005,6 +1043,11 @@ function writeNativeStream(
 
   const emitText = (text: string, isThinking?: boolean) => {
     if (writer.closed) return;
+    // A staged pause means the tool-call block is already on the response and `toolUse` is about to
+    // close it. Text emitted now would land *after* that block, which breaks the invariant that a
+    // tool-use turn ends on its tool call. Before the pause was deferred the closed writer dropped
+    // this text anyway, so nothing regresses by dropping it explicitly.
+    if (pauseRequested) return;
     if (isThinking) {
       emittedUserVisibleContent = true;
       writer.thinking(text);
@@ -1023,6 +1066,10 @@ function writeNativeStream(
   };
 
   const emitFlushed = () => {
+    // Same ordering rule as emitText: once a tool-call block is on the response, nothing may be
+    // appended after it. The first exec of a chunk flushes before staging its pause, so pending
+    // text still reaches the client ahead of the tool call.
+    if (pauseRequested) return;
     const flushed = tagFilter.flush();
     if (flushed.reasoning) {
       emittedUserVisibleContent = true;
@@ -1057,25 +1104,36 @@ function writeNativeStream(
               toolName: exec.toolName,
               arguments: parseToolCallArguments(exec.decodedArgs),
             });
+
+            // Emit before snapshotting: an exec the writer refuses is one the client will never
+            // answer, so it must not be recorded as pending.
+            if (!writer.closed) {
+              writer.toolCall(exec);
+              emittedExecs.push(exec);
+              pauseRequested = true;
+            }
+
             const stored = conversationStates.get(convKey);
-            if (stored) {
+            // Nothing reached the client, so there is no continuation to snapshot — and writing an
+            // empty one here would clear a checkpoint this stream may still need.
+            if (stored && emittedExecs.length > 0) {
               commitStoredCheckpointMidPause(
                 stored,
-                latestCheckpoint,
+                checkpointRef.current,
                 blobStore,
                 completedTurns,
-                state.pendingExecs,
+                emittedExecs,
               );
               debugLog(
-                latestCheckpoint
+                checkpointRef.current
                   ? "native.stream.tool_call_checkpoint_saved"
                   : "native.stream.tool_call_snapshot_saved",
                 {
                   requestId,
                   bridgeKey,
                   convKey,
-                  checkpointSource: latestCheckpoint ? "upstream" : "absent",
-                  pendingToolCallIds: state.pendingExecs.map((e) => e.toolCallId),
+                  checkpointSource: checkpointRef.current ? "upstream" : "absent",
+                  pendingToolCallIds: emittedExecs.map((e) => e.toolCallId),
                 },
               );
             }
@@ -1087,22 +1145,21 @@ function writeNativeStream(
               mcpTools,
               pendingExecs: state.pendingExecs,
               currentTurn,
+              checkpointRef,
+              state,
+              historyFingerprint: historyFingerprint(),
             });
             debugLog("native.stream.tool_call_pause", {
               requestId,
               bridgeKey,
               exec,
               pendingExecs: state.pendingExecs,
+              emittedToolCallIds: emittedExecs.map((e) => e.toolCallId),
               currentTurn,
             });
-
-            if (!writer.closed) {
-              writer.toolCall(exec);
-              writer.done("toolUse", state);
-            }
           },
           (checkpointBytes) => {
-            latestCheckpoint = checkpointBytes;
+            checkpointRef.current = checkpointBytes;
             debugLog("native.stream.checkpoint_buffered", { requestId, convKey, checkpointBytes });
           },
         );
@@ -1126,8 +1183,12 @@ function writeNativeStream(
           message: endError.message,
           enhanced,
           isAuthError: isAuthErrorMessage(endError.message),
+          deferredToToolPause: pauseRequested,
         });
-        writer.error(enhanced, "error", state);
+        // A tool pause staged earlier in this same chunk wins: the client needs the tool call to
+        // continue, and `streamError` still routes the close through mid-pause snapshotting so the
+        // returning results land in recovery rather than on a bridge nobody is holding.
+        if (!pauseRequested) writer.error(enhanced, "error", state);
       }
     },
   );
@@ -1137,6 +1198,12 @@ function writeNativeStream(
     // (notably `interactionUpdate{tokenDelta}`-only frames) cannot keep the stream alive
     // forever.
     processChunk(chunk);
+    // Closing the response is deferred to here so that every exec framed in this chunk reaches
+    // the client, not just the first. Parallel tool calls arrive as sibling frames.
+    if (pauseRequested) {
+      pauseRequested = false;
+      if (!writer.closed) writer.done("toolUse", state);
+    }
   });
 
   bridge.onClose((code) => {
@@ -1148,7 +1215,7 @@ function writeNativeStream(
       cancelled,
       mcpExecReceived,
       currentTurn,
-      latestCheckpoint,
+      latestCheckpoint: checkpointRef.current,
     });
     lifecycleLog("bridge_close", {
       requestId,
@@ -1158,7 +1225,7 @@ function writeNativeStream(
       cancelled,
       mcpExecReceived,
       emittedUserVisibleContent,
-      hasCheckpoint: !!latestCheckpoint,
+      hasCheckpoint: !!checkpointRef.current,
     });
     idleWatchdog.clear();
     clearInterval(heartbeatTimer);
@@ -1170,10 +1237,10 @@ function writeNativeStream(
       if (mcpExecReceived) {
         const midPauseResult = handleBridgeCloseMidPause({
           stored,
-          latestCheckpoint,
+          latestCheckpoint: checkpointRef.current,
           blobStore,
           completedTurns,
-          pendingExecs: state.pendingExecs,
+          pendingExecs: emittedExecs,
         });
         debugLog(
           midPauseResult.committed
@@ -1184,7 +1251,7 @@ function writeNativeStream(
             bridgeKey,
             convKey,
             cause: "stream_error",
-            pendingToolCallIds: state.pendingExecs.map((e) => e.toolCallId),
+            pendingToolCallIds: emittedExecs.map((e) => e.toolCallId),
           },
         );
       }
@@ -1196,10 +1263,10 @@ function writeNativeStream(
       if (mcpExecReceived) {
         const midPauseResult = handleBridgeCloseMidPause({
           stored,
-          latestCheckpoint,
+          latestCheckpoint: checkpointRef.current,
           blobStore,
           completedTurns,
-          pendingExecs: state.pendingExecs,
+          pendingExecs: emittedExecs,
         });
         debugLog(
           midPauseResult.committed
@@ -1210,7 +1277,7 @@ function writeNativeStream(
             bridgeKey,
             convKey,
             code,
-            pendingToolCallIds: state.pendingExecs.map((e) => e.toolCallId),
+            pendingToolCallIds: emittedExecs.map((e) => e.toolCallId),
           },
         );
       }
@@ -1222,8 +1289,14 @@ function writeNativeStream(
     if (!mcpExecReceived) {
       emitFlushed();
       if (stored) {
-        if (latestCheckpoint) {
-          commitStoredCheckpoint(stored, latestCheckpoint, blobStore, completedTurns, currentTurn);
+        if (checkpointRef.current) {
+          commitStoredCheckpoint(
+            stored,
+            checkpointRef.current,
+            blobStore,
+            completedTurns,
+            currentTurn,
+          );
           debugLog("native.stream.checkpoint_committed", { requestId, convKey, stored });
         } else {
           mergeBlobStore(stored, blobStore);
@@ -1233,10 +1306,10 @@ function writeNativeStream(
     } else {
       const midPauseResult = handleBridgeCloseMidPause({
         stored,
-        latestCheckpoint,
+        latestCheckpoint: checkpointRef.current,
         blobStore,
         completedTurns,
-        pendingExecs: state.pendingExecs,
+        pendingExecs: emittedExecs,
       });
       debugLog(
         midPauseResult.committed
@@ -1246,7 +1319,7 @@ function writeNativeStream(
           requestId,
           bridgeKey,
           convKey,
-          pendingToolCallIds: state.pendingExecs.map((e) => e.toolCallId),
+          pendingToolCallIds: emittedExecs.map((e) => e.toolCallId),
         },
       );
       removeActiveBridge(bridgeKey);
@@ -1289,7 +1362,17 @@ function handleNativeToolResultResume(
     cursorModelParameters,
     getAccessToken,
   } = ctx;
-  const { bridge, heartbeatTimer, blobStore, mcpTools, pendingExecs, currentTurn } = active;
+  const {
+    bridge,
+    heartbeatTimer,
+    blobStore,
+    mcpTools,
+    pendingExecs,
+    currentTurn,
+    checkpointRef,
+    state: pausedState,
+    historyFingerprint,
+  } = active;
   const resumeIdleTimeoutMs = resolveResumeIdleTimeoutMs(
     process.env.PI_CURSOR_RESUME_IDLE_TIMEOUT_MS,
   );
@@ -1326,6 +1409,9 @@ function handleNativeToolResultResume(
       mcpTools,
       pendingExecs,
       currentTurn,
+      checkpointRef,
+      state: pausedState,
+      historyFingerprint,
     });
     debugLog("native.tool_resume.partial_wait", {
       requestId,
@@ -1333,8 +1419,16 @@ function handleNativeToolResultResume(
       unresolvedExecs,
       currentTurn,
     });
+    // Re-emitting here is the only way the client learns about execs that arrived after its
+    // response closed, so the snapshot has to grow with them.
+    const stored = conversationStates.get(convKey);
+    if (stored) {
+      commitStoredCheckpointMidPause(stored, checkpointRef.current, blobStore, completedTurns, [
+        ...pendingExecs,
+      ]);
+    }
     for (const exec of unresolvedExecs) writer.toolCall(exec);
-    writer.done("toolUse");
+    writer.done("toolUse", pausedState);
     return;
   }
 
@@ -1463,22 +1557,25 @@ function handleNativeToolResultResume(
         attempt: nextAttempt,
         pendingToolCallIds: toolResults.map((r) => r.toolCallId),
       });
+      const recoveredUserImages = collectToolResultImages(toolResults);
       const recoveredCurrentTurn: ParsedTurn = {
         userText: decision.wrappedText,
         steps: [],
+        ...(recoveredUserImages.length ? { userImages: recoveredUserImages } : {}),
       };
-      const payload = buildCursorRequest(
+      const payload = buildCursorRequest({
         modelId,
         systemPrompt,
-        decision.wrappedText,
-        completedTurns,
-        decision.conversationId,
-        decision.checkpoint,
-        decision.blobStore,
+        userText: decision.wrappedText,
+        userImages: recoveredUserImages,
+        turns: completedTurns,
+        conversationId: decision.conversationId,
+        checkpoint: decision.checkpoint,
+        existingBlobStore: decision.blobStore,
         maxMode,
         cursorModelParameters,
         mcpTools,
-      );
+      });
       payload.mcpTools = mcpTools;
       startNativeStreamWithIdleRetries({
         accessToken,
@@ -1518,6 +1615,8 @@ function handleNativeToolResultResume(
     requestId,
     idleRetry,
     resumeIdleTimeoutMs,
+    // Same bridge, so the same checkpoint cell: frames that landed during the pause stay visible.
+    checkpointRef,
   );
 }
 

--- a/src/stream/recovery.ts
+++ b/src/stream/recovery.ts
@@ -245,6 +245,15 @@ export function stripInFlightResults(turn: ParsedTurn): ParsedTurn {
   };
 }
 
+/**
+ * A tool message with no `tool_call_id` parses to an empty id. Several of those in one turn look
+ * like duplicates to the set validators and would fail an otherwise sound recovery, so they are
+ * excluded from matching — they can never correspond to an exec either way.
+ */
+function identifiableToolCallId(toolCallId: string): boolean {
+  return toolCallId !== "";
+}
+
 function setsEqual(a: Set<string>, b: Set<string>): boolean {
   return a.size === b.size && [...a].every((id) => b.has(id));
 }
@@ -273,6 +282,30 @@ export function validateExactToolResultMatch(
   const hasDuplicates =
     expectedSet.size !== expected.length || receivedSet.size !== received.length;
   if (hasDuplicates || !setsEqual(expectedSet, receivedSet)) {
+    return { ok: false, expected, received };
+  }
+  return { ok: true };
+}
+
+/**
+ * Mid-pause snapshots record only the execs of the round that was parked, because each resume
+ * re-enters the stream writer with fresh state. The client, by contrast, re-sends every tool
+ * result in the in-flight user turn — round 1's results as well as the parked round's. So the
+ * pending set must be *covered by* what arrived, not equal to it; demanding equality made every
+ * bridge loss after the second tool round unrecoverable.
+ *
+ * Exact-match validation still guards the in-flight turn (./validateExactToolResultMatch), which is
+ * what pins the replayed transcript to the client's view.
+ */
+export function validatePendingCoveredByReceived(
+  expected: string[],
+  received: string[],
+): { ok: true } | { ok: false; expected: string[]; received: string[] } {
+  const expectedSet = new Set(expected);
+  const receivedSet = new Set(received);
+  const hasDuplicates =
+    expectedSet.size !== expected.length || receivedSet.size !== received.length;
+  if (hasDuplicates || [...expectedSet].some((id) => !receivedSet.has(id))) {
     return { ok: false, expected, received };
   }
   return { ok: true };
@@ -320,14 +353,15 @@ export function planFullHistoryRebuild(
   const inFlightToolCallIds =
     strippedInFlightTurn?.steps
       .filter((step): step is ParsedToolCallStep => step.kind === "toolCall")
-      .map((step) => step.toolCallId) ?? [];
+      .map((step) => step.toolCallId)
+      .filter(identifiableToolCallId) ?? [];
   if (!strippedInFlightTurn || inFlightToolCallIds.length === 0 || input.toolResults.length === 0) {
     return skipRecovery("no_inflight_tool_continuation", hadStoredCheckpoint);
   }
 
-  const pendingIds = pendingToolCalls.map((c) => c.toolCallId);
-  const receivedIds = input.toolResults.map((r) => r.toolCallId);
-  const pendingVsReceived = validateExactToolResultMatch(pendingIds, receivedIds);
+  const pendingIds = pendingToolCalls.map((c) => c.toolCallId).filter(identifiableToolCallId);
+  const receivedIds = input.toolResults.map((r) => r.toolCallId).filter(identifiableToolCallId);
+  const pendingVsReceived = validatePendingCoveredByReceived(pendingIds, receivedIds);
   const inFlightVsReceived = validateExactToolResultMatch(inFlightToolCallIds, receivedIds);
   if (!pendingVsReceived.ok) {
     return skipRecovery(
@@ -398,9 +432,11 @@ export function planRecovery(input: PlanRecoveryInput): RecoveryDecision {
     return skipRecovery("stale_checkpoint", hadStoredCheckpointPreDiscard);
   }
 
-  const expected = (input.stored.midPausePendingToolCalls ?? []).map((c) => c.toolCallId);
-  const received = input.toolResults.map((r) => r.toolCallId);
-  const match = validateExactToolResultMatch(expected, received);
+  const expected = (input.stored.midPausePendingToolCalls ?? [])
+    .map((c) => c.toolCallId)
+    .filter(identifiableToolCallId);
+  const received = input.toolResults.map((r) => r.toolCallId).filter(identifiableToolCallId);
+  const match = validatePendingCoveredByReceived(expected, received);
   if (!match.ok) {
     const rebuilt = tryRebuild("checkpoint_tool_mismatch");
     if (rebuilt.kind !== "skip") return rebuilt;

--- a/src/stream/session-state.ts
+++ b/src/stream/session-state.ts
@@ -13,6 +13,9 @@
  */
 import { createHash } from "node:crypto";
 
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { ConversationStateStructureSchema } from "../proto/agent_pb.js";
 import { activeBridges, cleanupBridge } from "./bridge-session.js";
 import { debugLog } from "./debug-log.js";
 import { textContent } from "./message-parsing.js";
@@ -69,6 +72,21 @@ export function clearStoredCheckpoint(stored: StoredConversation, clearBlobStore
   if (clearBlobStore) stored.blobStore.clear();
 }
 
+/**
+ * Checkpoint bytes are replayed straight into `fromBinary` when a request is built. A truncated or
+ * otherwise undecodable checkpoint would throw there and fail the turn — and, because nothing
+ * clears it, every later turn in the conversation too. Decoding once here turns that permanent
+ * break into a one-time discard and a rebuild.
+ */
+function checkpointDecodes(checkpoint: Uint8Array): boolean {
+  try {
+    fromBinary(ConversationStateStructureSchema, checkpoint);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function discardStaleCheckpointIfNeeded(
   stored: StoredConversation,
   turns: ParsedTurn[],
@@ -82,8 +100,9 @@ export function discardStaleCheckpointIfNeeded(
   const currentHistoryFingerprint = fingerprintCompletedTurns(turns);
   const storedCheckpointTurnCount = stored.checkpointTurnCount;
   const storedCheckpointHistoryFingerprint = stored.checkpointHistoryFingerprint;
-  const reason =
-    storedCheckpointTurnCount === undefined || !storedCheckpointHistoryFingerprint
+  const reason = !checkpointDecodes(stored.checkpoint)
+    ? "checkpoint_undecodable"
+    : storedCheckpointTurnCount === undefined || !storedCheckpointHistoryFingerprint
       ? "missing_checkpoint_metadata"
       : storedCheckpointTurnCount !== currentTurnCount
         ? "completed_turn_count_mismatch"
@@ -130,7 +149,14 @@ export function mergeBlobStore(
   stored: StoredConversation,
   blobStore: Map<string, Uint8Array>,
 ): void {
-  for (const [k, v] of blobStore) stored.blobStore.set(k, v);
+  // Delete-then-set moves each still-referenced blob to the end of the insertion order, which is
+  // what `trimBlobStore` treats as newest. Plain `set` leaves an existing key in place, so the
+  // system-prompt blob — written first on every build, and pointed at by `rootPromptMessagesJson`
+  // in every checkpoint — stayed permanently oldest and would be the first thing evicted.
+  for (const [k, v] of blobStore) {
+    stored.blobStore.delete(k);
+    stored.blobStore.set(k, v);
+  }
   const trimmed = trimBlobStore(stored.blobStore);
   if (trimmed.removed > 0) {
     debugLog("conversation.blob_store_trimmed", {

--- a/src/stream/types.ts
+++ b/src/stream/types.ts
@@ -146,6 +146,17 @@ export interface PendingExec {
   decodedArgs: string;
 }
 
+/**
+ * Latest upstream checkpoint for a bridge, held by reference so it survives a tool pause.
+ *
+ * Each resume re-enters the stream writer with fresh locals, but the bridge — and the frames
+ * still arriving on it — outlive that boundary. A checkpoint delivered during a pause would be
+ * stranded in the previous round's closure without a shared cell.
+ */
+export interface CheckpointRef {
+  current: Uint8Array | null;
+}
+
 export interface ActiveBridge {
   bridge: BridgeHandle;
   heartbeatTimer: ReturnType<typeof setInterval>;
@@ -154,6 +165,10 @@ export interface ActiveBridge {
   mcpTools: McpToolDefinition[];
   pendingExecs: PendingExec[];
   currentTurn: ParsedTurn;
+  checkpointRef: CheckpointRef;
+  state: StreamState;
+  /** Fingerprint of the completed turns this bridge was parked on; guards against key collisions. */
+  historyFingerprint: string;
 }
 
 export interface StoredConversation {

--- a/tests/durability.test.ts
+++ b/tests/durability.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Failures that used to be permanent: state that, once bad, broke every later turn of a
+ * conversation rather than just the turn that produced it.
+ */
+import { describe, expect, it } from "vitest";
+import { parseMessages } from "../src/stream/message-parsing.js";
+import {
+  discardStaleCheckpointIfNeeded,
+  mergeBlobStore,
+  trimBlobStore,
+} from "../src/stream/session-state.js";
+import type { OpenAIMessage, StoredConversation } from "../src/stream/types.js";
+
+const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function pngDataUrl(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  bytes.set(PNG_HEADER);
+  return `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+function storedConversation(partial: Partial<StoredConversation> = {}): StoredConversation {
+  return {
+    conversationId: "conv-1",
+    checkpoint: null,
+    sessionScoped: false,
+    blobStore: new Map(),
+    lastAccessMs: Date.now(),
+    ...partial,
+  };
+}
+
+describe("oversized images in history", () => {
+  const oversized = pngDataUrl(6 * 1024 * 1024);
+
+  it("does not fail a turn because an older turn carried an unusable image", () => {
+    const messages: OpenAIMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this" },
+          { type: "image_url", image_url: { url: oversized } },
+        ],
+      },
+      { role: "assistant", content: "noted" },
+      { role: "user", content: "now do the next thing" },
+    ] as OpenAIMessage[];
+
+    const parsed = parseMessages(messages);
+
+    expect(parsed.turns).toHaveLength(1);
+    expect(parsed.turns[0]!.userImages ?? []).toHaveLength(0);
+    expect(parsed.userText).toBe("now do the next thing");
+  });
+
+  it("still rejects an unusable image on the turn being sent", () => {
+    const messages: OpenAIMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this" },
+          { type: "image_url", image_url: { url: oversized } },
+        ],
+      },
+    ] as OpenAIMessage[];
+
+    expect(() => parseMessages(messages)).toThrow(/exceeds Cursor CLI/);
+  });
+});
+
+describe("checkpoint durability", () => {
+  it("discards an undecodable checkpoint instead of replaying it forever", () => {
+    const stored = storedConversation({
+      checkpoint: new Uint8Array([0xff, 0xff, 0xff, 0xff]),
+      checkpointTurnCount: 0,
+      checkpointHistoryFingerprint: "whatever",
+    });
+
+    discardStaleCheckpointIfNeeded(stored, [], "r1", "c1");
+
+    expect(stored.checkpoint).toBeNull();
+  });
+});
+
+describe("blob store eviction order", () => {
+  it("keeps blobs that every build re-references instead of evicting them first", () => {
+    const stored = storedConversation();
+    const systemBlob = new Uint8Array(40).fill(1);
+    // Written first on every build and pointed at by every checkpoint.
+    mergeBlobStore(stored, new Map([["system", systemBlob]]));
+    mergeBlobStore(stored, new Map([["turn-1", new Uint8Array(40).fill(2)]]));
+    // A later build re-references the system blob; it must not stay the oldest entry.
+    mergeBlobStore(stored, new Map([["system", systemBlob]]));
+
+    trimBlobStore(stored.blobStore, 60);
+
+    expect(stored.blobStore.has("system")).toBe(true);
+    expect(stored.blobStore.has("turn-1")).toBe(false);
+  });
+});

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -75,6 +75,82 @@ describe("planRecovery", () => {
     }
   });
 
+  it("rebuilds when the bridge dies on a later tool round of the same user turn", () => {
+    // Round 2 parked only t2, but the client re-sends every result in the turn (t1 and t2).
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const stored = storedBase({
+      checkpoint: null,
+      midPausePendingToolCalls: [{ toolCallId: "t2", toolName: "read" }],
+      midPauseTurnCount: completedTurns.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(completedTurns),
+    });
+    const toolResults: ToolResultInfo[] = [
+      { toolCallId: "t1", content: "round one" },
+      { toolCallId: "t2", content: "round two" },
+    ];
+    const decision = planRecovery({
+      stored,
+      toolResults,
+      completedTurns,
+      inFlightTurn: toolTurn(["t1", "t2"]),
+      requestId: "r1",
+      convKey: "c1",
+    });
+    expect(decision.kind).toBe("rebuild_full_history");
+  });
+
+  it("still skips when a parked tool call has no result in the request", () => {
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const stored = storedBase({
+      checkpoint: null,
+      midPausePendingToolCalls: [
+        { toolCallId: "t1", toolName: "read" },
+        { toolCallId: "t2", toolName: "read" },
+      ],
+      midPauseTurnCount: completedTurns.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(completedTurns),
+    });
+    const decision = planRecovery({
+      stored,
+      toolResults: [{ toolCallId: "t1", content: "only one" }],
+      completedTurns,
+      inFlightTurn: toolTurn(["t1"]),
+      requestId: "r1",
+      convKey: "c1",
+    });
+    expect(decision.kind).toBe("skip");
+    if (decision.kind === "skip") {
+      expect(decision.reason).toBe("pending_tool_call_mismatch");
+    }
+  });
+
+  it("ignores unidentifiable tool results instead of reading them as duplicates", () => {
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const stored = storedBase({
+      checkpoint: null,
+      midPauseTurnCount: completedTurns.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(completedTurns),
+    });
+    const inFlightTurn = toolTurn(["t1"]);
+    inFlightTurn.steps.push(
+      { kind: "toolCall", toolCallId: "", toolName: "", arguments: {} },
+      { kind: "toolCall", toolCallId: "", toolName: "", arguments: {} },
+    );
+    const decision = planRecovery({
+      stored,
+      toolResults: [
+        { toolCallId: "t1", content: "ok" },
+        { toolCallId: "", content: "orphan a" },
+        { toolCallId: "", content: "orphan b" },
+      ],
+      completedTurns,
+      inFlightTurn,
+      requestId: "r1",
+      convKey: "c1",
+    });
+    expect(decision.kind).toBe("rebuild_full_history");
+  });
+
   it("recovers via checkpoint when pending tool ids match", () => {
     const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
     const checkpoint = new Uint8Array([1, 2, 3]);


### PR DESCRIPTION
Patch release fixing a set of tool-continuation and durability bugs in the native stream. 1.3.0 is already published and tagged, so this goes out as 1.3.1.

## What was breaking

**Recovery only ever worked on the first tool round.** Losing the bridge mid-tool failed with `skipReason=pending_tool_call_mismatch` on every round after the first. The mid-pause snapshot records only the round that was parked — each resume re-enters the stream writer with fresh state — while `parseMessages` hands recovery every tool result in the in-flight user turn. Recovery required the two sets to be equal. The parked set is now required to be *covered by* what arrived; the in-flight turn is still matched exactly, which is what pins the replayed transcript to the client's view.

**Three failures that were permanent rather than per-turn**, because the whole history and stored state are re-read on every request:

- an oversized or unsupported image anywhere in the transcript threw during parsing, failing not just its own turn but all later ones
- an undecodable checkpoint was replayed into `fromBinary` forever, with nothing to clear it
- `trimBlobStore` evicts oldest-insertion-first, but merging used `Map.set`, which leaves an existing key in place — so the system-prompt blob, written first on every build and referenced by every checkpoint, was permanently the oldest entry and first to be dropped

**Plus:** parallel execs past the first were dropped because the response closed on the first one; checkpoints arriving during a pause were stranded in the previous round's closure (a recurring source of `hadStoredCheckpoint=false`); tool-result images were lost on the checkpoint-recovery path though the rebuild path kept them; and a live bridge could be resumed for the wrong conversation when no Pi session id makes the bridge key a hash of the opening message alone.

## Verification

`npm run check` passes — typecheck, lint, format, security-check, proto-check, and 55 tests (up from 48).

**Coverage gap worth knowing about.** The recovery and durability fixes are unit-tested. The stream-level ones — deferred pause, shared checkpoint ref, history-fingerprint guard — are **not**, because there is no fake-bridge harness in the repo; `setBridgeFactoryForTests` is exported but unused. Those were verified by reading, not by running, and have not been exercised against a live Cursor bridge. A multi-round tool session is the thing to try before trusting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery and continuation after tool-use pauses.
  * Preserved parallel tool calls and tool-result images during recovery.
  * Prevented invalid historical images and corrupted checkpoints from blocking later turns.
  * Improved checkpoint handling and blob retention.
  * Prevented incorrect live-session resumption when conversation history differs.
  * Improved matching of tool results during recovery.

* **Tests**
  * Added coverage for image handling, checkpoint recovery, blob retention, and tool-call recovery scenarios.

* **Release**
  * Updated the release version to 1.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->