### PR TITLE
fix: do not retry a completed turn when Cursor closes the stream (#3)

### DIFF
--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -264,6 +264,7 @@ export const __testInternals = {
   persistAbortedConversationState,
   trimBlobStore,
   classifyBridgeExit,
+  writeNativeStream,
   setMetricEmitterForTests(factory?: MetricEmitter) {
     setMetricEmitter(factory);
   },
@@ -973,6 +974,7 @@ function writeNativeStream(
     pendingExecs: [],
     outputTokens: 0,
     totalTokens: 0,
+    turnEnded: false,
   };
   const tagFilter = createThinkingTagFilter();
   let mcpExecReceived = false;
@@ -1267,6 +1269,16 @@ function writeNativeStream(
     (endStreamBytes) => {
       const endError = parseConnectEndStream(endStreamBytes);
       if (endError) {
+        // Cursor closes the connection right after `turnEnded`. That close ends a completed
+        // turn; reporting it as an error made Pi retry and duplicate the answer (upstream #3).
+        if (state.turnEnded && !pauseRequested) {
+          debugLog("native.stream.post_turn_close", {
+            requestId,
+            modelId,
+            message: endError.message,
+          });
+          return;
+        }
         streamError = endError;
         const enhanced = enhanceCursorStreamError(endError.message);
         debugLog("native.stream.cursor_error", {
@@ -1352,7 +1364,11 @@ function writeNativeStream(
       return;
     }
 
-    if (code !== 0) {
+    // Same completed-turn rule as the end-stream frame: the non-zero exit that follows a
+    // GOAWAY after `turnEnded` must finalize the turn, not restart it (upstream #3).
+    const completedTurnClose = state.turnEnded && !mcpExecReceived;
+
+    if (code !== 0 && !completedTurnClose) {
       const failure = classifyBridgeExit({
         exitCode: code,
         stderr: typeof bridge.lastStderr === "function" ? bridge.lastStderr() : "",

--- a/src/stream/server-messages.ts
+++ b/src/stream/server-messages.ts
@@ -143,6 +143,15 @@ export function processServerMessage(
       }
       return interactionUpdateCountsAsProgress(updateCase);
     }
+    if (updateCase === "turnEnded") {
+      // Cursor closes the HTTP/2 connection right after this. Recorded so the close is
+      // finalized as a completed turn instead of retried as a failure (upstream #3).
+      state.turnEnded = true;
+      return true;
+    }
+    // Liveness cases (heartbeat, toolCallStarted, partialToolCall, ...) are already defined by
+    // interactionUpdateCountsAsProgress; reuse it rather than keeping a second list here.
+    if (interactionUpdateCountsAsProgress(updateCase)) return true;
     // Unrecognized update cases are informational rather than stranding — the
     // stream keeps flowing — but they are the first sign our schema is behind.
     recordDriftSignal("interaction_update", updateCase);

--- a/src/stream/types.ts
+++ b/src/stream/types.ts
@@ -192,6 +192,8 @@ export interface StreamState {
   pendingExecs: PendingExec[];
   outputTokens: number;
   totalTokens: number;
+  /** Set once Cursor reported `turnEnded`; a connection close after it is a completed turn. */
+  turnEnded: boolean;
 }
 
 // ── Native streamSimple runtime ──

--- a/tests/idle-progress.test.ts
+++ b/tests/idle-progress.test.ts
@@ -1,4 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import {
+  AgentServerMessageSchema,
+  HeartbeatUpdateSchema,
+  InteractionUpdateSchema,
+  PartialToolCallUpdateSchema,
+  ToolCallStartedUpdateSchema,
+} from "../src/proto/agent_pb.js";
+import { processServerMessage } from "../src/stream/server-messages.js";
+import type { StreamState } from "../src/stream/types.js";
 import {
   __testInternals,
   canBlindIdleRestart,
@@ -21,6 +31,39 @@ describe("idle progress classification", () => {
     expect(interactionUpdateCountsAsProgress("heartbeat")).toBe(true);
     expect(interactionUpdateCountsAsProgress("thinkingCompleted")).toBe(true);
     expect(interactionUpdateCountsAsProgress("toolCallStarted")).toBe(true);
+  });
+
+  it("resets the watchdog for liveness updates the dispatcher receives", () => {
+    const liveness = [
+      { case: "heartbeat" as const, value: create(HeartbeatUpdateSchema, {}) },
+      { case: "toolCallStarted" as const, value: create(ToolCallStartedUpdateSchema, {}) },
+      { case: "partialToolCall" as const, value: create(PartialToolCallUpdateSchema, {}) },
+    ];
+    for (const message of liveness) {
+      const state: StreamState = {
+        toolCallIndex: 0,
+        pendingExecs: [],
+        outputTokens: 0,
+        totalTokens: 0,
+        turnEnded: false,
+      };
+      const serverMessage = create(AgentServerMessageSchema, {
+        message: {
+          case: "interactionUpdate",
+          value: create(InteractionUpdateSchema, { message }),
+        },
+      });
+      const madeProgress = processServerMessage(
+        serverMessage,
+        new Map(),
+        [],
+        () => {},
+        state,
+        () => {},
+        () => {},
+      );
+      expect([message.case, madeProgress]).toEqual([message.case, true]);
+    }
   });
 
   it("requires non-empty text for text/thinking deltas", () => {

--- a/tests/transport-recovery.test.ts
+++ b/tests/transport-recovery.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { create, toBinary } from "@bufbuild/protobuf";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import {
+  AgentServerMessageSchema,
+  InteractionUpdateSchema,
+  TextDeltaUpdateSchema,
+  TurnEndedUpdateSchema,
+  type InteractionUpdate,
+} from "../src/proto/agent_pb.js";
+import { frameConnectMessage } from "../src/client/bridge.js";
+import { __testInternals } from "../src/stream/native-core.js";
 import {
   canBlindIdleRestart,
   canRecoverAfterTransportLoss,
@@ -159,5 +169,105 @@ describe("durable run journal", () => {
     expect(loaded!.conversationId).toBe("conv-journal-1");
     expect(loaded!.sessionId).toBe("session-1");
     expect(Array.from(loaded!.checkpoint ?? [])).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("completed-turn connection close", () => {
+  function frame(bytes: Uint8Array, flags = 0): Buffer {
+    return frameConnectMessage(bytes, flags);
+  }
+
+  function updateFrame(message: InteractionUpdate["message"]): Buffer {
+    return frame(
+      toBinary(
+        AgentServerMessageSchema,
+        create(AgentServerMessageSchema, {
+          message: {
+            case: "interactionUpdate",
+            value: create(InteractionUpdateSchema, { message }),
+          },
+        }),
+      ),
+    );
+  }
+
+  it("finalizes the turn when Cursor GOAWAYs after turnEnded (upstream #3)", () => {
+    const calls: string[] = [];
+    const writer = {
+      output: {} as never,
+      closed: false,
+      start() {},
+      text() {},
+      thinking() {},
+      toolCall() {},
+      done(reason: string) {
+        calls.push(`done:${reason}`);
+        this.closed = true;
+      },
+      error(message: string) {
+        calls.push(`error:${message}`);
+        this.closed = true;
+      },
+    };
+    let onData: (chunk: Buffer) => void = () => {};
+    let onClose: (code: number) => void = () => {};
+    const bridge = {
+      proc: { kill: () => true },
+      alive: true,
+      lastStderr: () => "GOAWAY errorCode=0",
+      write: () => {},
+      end: () => {},
+      onData: (cb: (chunk: Buffer) => void) => {
+        onData = cb;
+      },
+      onClose: (cb: (code: number) => void) => {
+        onClose = cb;
+      },
+    };
+    const heartbeatTimer = setInterval(() => {}, 60_000);
+
+    __testInternals.writeNativeStream(
+      bridge,
+      heartbeatTimer,
+      new Map(),
+      [],
+      {} as never,
+      "claude-4.5-sonnet",
+      "bridge-key",
+      "conv-key",
+      [],
+      { userText: "hi", steps: [] },
+      writer as never,
+      undefined,
+      "req-1",
+      undefined,
+      0,
+    );
+
+    onData(
+      updateFrame({
+        case: "textDelta",
+        value: create(TextDeltaUpdateSchema, { text: "hello" }),
+      }),
+    );
+    onData(updateFrame({ case: "turnEnded", value: create(TurnEndedUpdateSchema, {}) }));
+    // Cursor's GOAWAY arrives as a Connect end-stream error, then the bridge exits 2.
+    onData(
+      frame(
+        new TextEncoder().encode(
+          JSON.stringify({
+            error: {
+              code: "unavailable",
+              message: "Cursor GOAWAY (errorCode=0): upstream connection closed, retriable",
+            },
+          }),
+        ),
+        2,
+      ),
+    );
+    onClose(2);
+    clearInterval(heartbeatTimer);
+
+    expect(calls).toEqual(["done:stop"]);
   });
 });


### PR DESCRIPTION
## What

Two fixes in the native stream path, both scoped to `src/stream/`:

1. **A clean connection close after `turnEnded` is no longer an error.** Cursor
   ends the HTTP/2 connection with `GOAWAY (errorCode=0)` right after a normal
   turn end. The stream surfaced that as a Connect end-stream error and, on the
   non-zero bridge exit that follows, as a retryable transport failure — so Pi
   retried a turn that had already completed and printed a duplicate answer
   (`Retry failed after 2 attempts: Retry cancelled`). `StreamState` now records
   `turnEnded`, and both close paths finalize the turn with
   `writer.done("stop")` instead of erroring/restarting. Mid-tool-pause closes
   are untouched (`!mcpExecReceived` / `!pauseRequested` guards).

2. **`heartbeat`, `toolCallStarted` and `partialToolCall` reset the idle
   watchdog again.** `interactionUpdateCountsAsProgress()` already classifies
   them as liveness, but `processServerMessage()` only had explicit branches for
   `textDelta`/`thinkingDelta`/`tokenDelta`/`toolCallCompleted`; everything else
   fell through to `recordDriftSignal(...)` + `return false`. Unmatched cases now
   go through the existing liveness definition first (no second list), so those
   updates count as progress instead of showing up as `interaction_update:heartbeat`
   wire drift.

This implements option 2 from the "Expected behavior" section of #3
(*"If the turn has already reached `turnEnded`, treat a subsequent HTTP/2 GOAWAY
with errorCode=0 as a completed turn instead of retrying and duplicating output"*)
— credit to the reporter of that issue for the diagnosis. It deliberately does
**not** touch `proto/agent.proto` or the generated `src/proto/agent_pb.ts`; the
remaining unknown-field drift reported in #3 is a separate concern.

## Tests

Both are red without the source change:

- `tests/idle-progress.test.ts` — drives `processServerMessage()` with real
  `heartbeat` / `toolCallStarted` / `partialToolCall` server messages and asserts
  they report progress (previously `false`).
- `tests/transport-recovery.test.ts` — drives `writeNativeStream()` with a fake
  bridge through `textDelta` → `turnEnded` → Connect end-stream `GOAWAY` error →
  `onClose(2)` and asserts the writer sees exactly `done("stop")` (previously an
  `error(...)`). `writeNativeStream` is exported through the existing
  `__testInternals` seam for this.

`npm run check` (typecheck, lint, format:check, security-check, proto:check,
vitest) passes.

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream recovery after a completed turn, preventing duplicate retries and false errors.
  * Correctly recognizes heartbeat, tool-call, and partial tool-call updates as active progress.
  * Handles connection closures and bridge exits gracefully after turn completion.

* **Tests**
  * Added coverage for idle-progress updates and completed-turn transport recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->