### PR TITLE
fix(models): use documented Cursor context windows per model family

### DIFF
--- a/src/models/context-windows.ts
+++ b/src/models/context-windows.ts
@@ -1,0 +1,112 @@
+/**
+ * Curated context-window table for Cursor model families.
+ *
+ * Cursor's discovery RPCs do not carry a context window for every model
+ * (`ModelDetails` has no such field at all), so the extension used to guess the
+ * window from the display name and fell back to 200k for everything else. That
+ * guess is wrong in both directions: Cursor names several rows "1M" while
+ * capping the default window far lower, and it gives Grok 256k where the
+ * fallback claimed 200k.
+ *
+ * Rules for this table:
+ * - `defaultWindow` is Cursor's *default* context window, not the model's
+ *   native window. Cursor may cap tighter than the provider does, and reporting
+ *   a window that is too large is worse than one that is too small: Pi would
+ *   never compact and would run into a server-side rejection instead.
+ * - `maxModeWindow` is only set where Cursor documents that Max Mode unlocks a
+ *   larger window. Families without a documented Max Mode window keep their
+ *   default even when `max_mode` is requested.
+ * - Every entry names its source. When in doubt, take the smaller documented
+ *   value and say so in the entry comment.
+ *
+ * Primary source: Cursor's own per-model table ("Default Context" / "Max
+ * Context") on https://cursor.com/docs/models-and-pricing, read 2026-08-13.
+ */
+
+export interface CursorContextWindowEntry {
+  /** Model-id prefix, matched after stripping a leading `cursor-`. */
+  readonly prefix: string;
+  /** Cursor's default context window for this family. */
+  readonly defaultWindow: number;
+  /** Window Cursor unlocks with Max Mode, if it documents one. */
+  readonly maxModeWindow?: number;
+  /** Where the numbers come from. */
+  readonly source: string;
+}
+
+/**
+ * Window reported when neither the table nor the display-name heuristic matches.
+ * This is Cursor's documented standard context window for normal mode.
+ * Source: https://cursor.com/docs/models-and-pricing (Max Mode "extends a
+ * model's context window beyond the default limit").
+ */
+export const CURSOR_FALLBACK_CONTEXT_WINDOW = 200_000;
+
+const CURSOR_DOCS = "https://cursor.com/docs/models-and-pricing (read 2026-08-13)";
+
+export const CURSOR_CONTEXT_WINDOWS: readonly CursorContextWindowEntry[] = [
+  {
+    prefix: "claude-fable-5",
+    defaultWindow: 300_000,
+    maxModeWindow: 1_000_000,
+    source: CURSOR_DOCS,
+  },
+  {
+    prefix: "claude-opus-5",
+    defaultWindow: 300_000,
+    maxModeWindow: 1_000_000,
+    source: CURSOR_DOCS,
+  },
+  {
+    prefix: "claude-sonnet-5",
+    defaultWindow: 200_000,
+    maxModeWindow: 1_000_000,
+    source: CURSOR_DOCS,
+  },
+  // Composer 2.5 has no Max Context in Cursor's table.
+  { prefix: "composer-2.5", defaultWindow: 200_000, source: CURSOR_DOCS },
+  {
+    prefix: "gemini-3.1-pro",
+    defaultWindow: 200_000,
+    maxModeWindow: 1_000_000,
+    source: CURSOR_DOCS,
+  },
+  {
+    prefix: "gemini-3.6-flash",
+    defaultWindow: 200_000,
+    maxModeWindow: 1_000_000,
+    source: CURSOR_DOCS,
+  },
+  // Luna and Terra are listed with no Max Context, Sol with 1M.
+  { prefix: "gpt-5.6-luna", defaultWindow: 272_000, source: CURSOR_DOCS },
+  { prefix: "gpt-5.6-sol", defaultWindow: 272_000, maxModeWindow: 1_000_000, source: CURSOR_DOCS },
+  { prefix: "gpt-5.6-terra", defaultWindow: 272_000, source: CURSOR_DOCS },
+  // Cursor ships these as `cursor-grok-4.x-*`; no Max Context documented.
+  { prefix: "grok-4.5", defaultWindow: 256_000, source: CURSOR_DOCS },
+  { prefix: "grok-4.6", defaultWindow: 256_000, source: CURSOR_DOCS },
+  {
+    // Hidden-by-default model, so it is absent from the context table. Only the
+    // Max Mode window is documented ("Up to 1M tokens with extended context",
+    // "Requires Max Mode"); the default is assumed to be Cursor's standard
+    // 200k, which is the conservative choice.
+    prefix: "kimi-k3",
+    defaultWindow: 200_000,
+    maxModeWindow: 1_000_000,
+    source: `${CURSOR_DOCS} — pricing notes only, default window unconfirmed`,
+  },
+] as const;
+
+/**
+ * Documented context window for a Cursor model id, or `undefined` when the
+ * family is not in the table. Longest matching prefix wins.
+ */
+export function lookupCursorContextWindow(id: string, maxMode = false): number | undefined {
+  const normalized = id.toLowerCase().replace(/^cursor-/, "");
+  let best: CursorContextWindowEntry | undefined;
+  for (const entry of CURSOR_CONTEXT_WINDOWS) {
+    if (!normalized.startsWith(entry.prefix)) continue;
+    if (!best || entry.prefix.length > best.prefix.length) best = entry;
+  }
+  if (!best) return undefined;
+  return maxMode ? (best.maxModeWindow ?? best.defaultWindow) : best.defaultWindow;
+}

--- a/src/stream/model-discovery.ts
+++ b/src/stream/model-discovery.ts
@@ -22,6 +22,10 @@ import {
 import { callUnaryOverH2, supportsInProcessH2 } from "../client/h2-unary.js";
 import { getBridgeFactory } from "./bridge-session.js";
 import { getCursorAgentUrl } from "./config.js";
+import {
+  CURSOR_FALLBACK_CONTEXT_WINDOW,
+  lookupCursorContextWindow,
+} from "../models/context-windows.js";
 import { writeCachedCatalog } from "./model-cache.js";
 
 export async function callCursorUnaryRpc(options: {
@@ -243,11 +247,19 @@ export async function discoverCursorCatalog(
   return { rawModels, parameterizedModels };
 }
 
-export function inferCursorContextWindow(id: string, name: string): number {
+/**
+ * Context window for a model Cursor discovery returned without one.
+ *
+ * Curated per-family table first (see `src/models/context-windows.ts`), then
+ * the legacy display-name heuristic, then Cursor's documented default window.
+ */
+export function inferCursorContextWindow(id: string, name: string, maxMode = false): number {
+  const documented = lookupCursorContextWindow(id, maxMode);
+  if (documented !== undefined) return documented;
   const text = `${id} ${name}`.toLowerCase();
   if (/\b1\s*m\b|(?:^|-)1m(?:-|$)/.test(text)) return 1_000_000;
   if (/\b272\s*k\b|(?:^|-)272k(?:-|$)/.test(text)) return 272_000;
-  return 200_000;
+  return CURSOR_FALLBACK_CONTEXT_WINDOW;
 }
 
 function normalizeCursorModels(models: readonly unknown[]): CursorModel[] {
@@ -261,7 +273,7 @@ function normalizeCursorModels(models: readonly unknown[]): CursorModel[] {
       id,
       name,
       reasoning: Boolean(m.thinkingDetails),
-      contextWindow: inferCursorContextWindow(id, name),
+      contextWindow: inferCursorContextWindow(id, name, Boolean(m.maxMode)),
       maxTokens: 64_000,
     });
   }

--- a/tests/context-window.test.ts
+++ b/tests/context-window.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  CURSOR_FALLBACK_CONTEXT_WINDOW,
+  lookupCursorContextWindow,
+} from "../src/models/context-windows.js";
+import { inferCursorContextWindow } from "../src/stream/model-discovery.js";
+
+describe("lookupCursorContextWindow", () => {
+  it("returns the documented default window per family", () => {
+    expect(lookupCursorContextWindow("cursor-grok-4.6-high")).toBe(256_000);
+    expect(lookupCursorContextWindow("gemini-3.6-flash-low")).toBe(200_000);
+    expect(lookupCursorContextWindow("gpt-5.6-sol-medium")).toBe(272_000);
+    expect(lookupCursorContextWindow("claude-opus-5-thinking-high")).toBe(300_000);
+  });
+
+  it("returns the documented max-mode window only where Cursor unlocks one", () => {
+    expect(lookupCursorContextWindow("gemini-3.6-flash-low", true)).toBe(1_000_000);
+    expect(lookupCursorContextWindow("claude-sonnet-5-high", true)).toBe(1_000_000);
+    expect(lookupCursorContextWindow("kimi-k3-max", true)).toBe(1_000_000);
+    // Grok and Composer have no documented Max Mode window: stay at the default.
+    expect(lookupCursorContextWindow("cursor-grok-4.6-high", true)).toBe(256_000);
+    expect(lookupCursorContextWindow("composer-2.5-fast", true)).toBe(200_000);
+  });
+
+  it("does not match unknown families", () => {
+    expect(lookupCursorContextWindow("some-future-model-high")).toBeUndefined();
+  });
+});
+
+describe("inferCursorContextWindow", () => {
+  it("prefers the table over the display-name heuristic", () => {
+    // Cursor names these rows "... 1M" but caps the default window lower.
+    expect(inferCursorContextWindow("gpt-5.6-sol-medium", "GPT-5.6 Sol 1M")).toBe(272_000);
+    expect(inferCursorContextWindow("claude-sonnet-5-high", "Sonnet 5 1M")).toBe(200_000);
+    expect(inferCursorContextWindow("claude-fable-5-high", "Fable 5 1M (NO ZDR)")).toBe(300_000);
+  });
+
+  it("fixes families that used to fall through to the 200k fallback", () => {
+    expect(inferCursorContextWindow("cursor-grok-4.5-medium", "Cursor Grok 4.5 Medium")).toBe(
+      256_000,
+    );
+    expect(inferCursorContextWindow("gemini-3.1-pro", "Gemini 3.1 Pro", true)).toBe(1_000_000);
+    expect(inferCursorContextWindow("kimi-k3-high", "Kimi K3 High", true)).toBe(1_000_000);
+  });
+
+  it("keeps the display-name heuristic for untabled models", () => {
+    expect(inferCursorContextWindow("claude-4.6-opus-high", "Opus 4.6 1M")).toBe(1_000_000);
+    expect(inferCursorContextWindow("gpt-5.5-high", "GPT-5.5 272K High")).toBe(272_000);
+  });
+
+  it("falls back to the documented Cursor default for unknown models", () => {
+    expect(inferCursorContextWindow("mystery-1", "Mystery")).toBe(CURSOR_FALLBACK_CONTEXT_WINDOW);
+    expect(CURSOR_FALLBACK_CONTEXT_WINDOW).toBe(200_000);
+  });
+});


### PR DESCRIPTION
## Problem

`inferCursorContextWindow` derives a model's context window from its display name and falls back to a flat `200_000` for anything else. That is wrong in both directions:

- **Too high:** Cursor names rows like `GPT-5.6 Sol 1M` / `Sonnet 5 1M` / `Fable 5 1M`, so every one of them is registered with a 1M window, while Cursor's own docs cap the *default* window at 272k / 200k / 300k. A window reported too large is the harmful case: the agent never compacts and runs into a server-side rejection instead.
- **Too low:** Grok 4.5/4.6 get 200k from the fallback, but Cursor documents 256k.
- **Max Mode ignored:** `ModelDetails.max_mode` is already on the wire and unused, so rows that Cursor does extend to 1M (Gemini, Sonnet 5, Opus 5, Fable 5, GPT-5.6 Sol, Kimi K3) are indistinguishable from ones that are not extended (Grok, Composer, GPT-5.6 Luna/Terra).

`GetUsableModels` has no context-window field at all, so a table is the only available source. (The parameterized path already uses `contextTokenLimit` from the wire and is untouched.)

## Change

- New `src/models/context-windows.ts`: one curated table keyed by model-id prefix, each entry carrying `defaultWindow`, an optional `maxModeWindow`, and its source. Values come from Cursor's own "Default Context" / "Max Context" table on <https://cursor.com/docs/models-and-pricing>.
- `inferCursorContextWindow(id, name, maxMode)` now resolves: table → existing display-name heuristic → named `CURSOR_FALLBACK_CONTEXT_WINDOW` (still 200k, just no longer a magic number).
- `normalizeCursorModels` passes `ModelDetails.max_mode` through.

Table policy, since Cursor can cap tighter than the provider does: entries record Cursor's window, not the model's native one; `maxModeWindow` is set only where Cursor documents a larger Max Mode window; when a value is uncertain the smaller one is taken and the uncertainty is named in the entry comment (currently only Kimi K3, which is hidden-by-default and therefore absent from the context table).

| Family | Default | Max Mode |
| --- | --- | --- |
| `claude-fable-5`, `claude-opus-5` | 300k | 1M |
| `claude-sonnet-5` | 200k | 1M |
| `composer-2.5` | 200k | – |
| `gemini-3.1-pro`, `gemini-3.6-flash` | 200k | 1M |
| `gpt-5.6-luna`, `gpt-5.6-terra` | 272k | – |
| `gpt-5.6-sol` | 272k | 1M |
| `grok-4.5`, `grok-4.6` | 256k | – |
| `kimi-k3` | 200k (assumed) | 1M |

Families not in the table (Claude 4.x, GPT-5.1–5.5, Gemini 3/3.5 Flash, GLM, Codex) keep exactly today's behaviour.

## Tests

`tests/context-window.test.ts` asserts the expected window per known family, the max-mode variants, the table-over-heuristic precedence, and the unchanged fallback. It fails on `main` (Grok/Gemini/Kimi/GPT-5.6). `npm run check` is green; protobuf sources untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added curated context-window limits for supported Cursor models.
  * Added support for Max Mode-specific context limits where documented.
  * Added a fallback context window for unrecognized models.
  * Improved model recognition using normalized IDs and family matching.

* **Bug Fixes**
  * Corrected context-window inference for model families and untabled models.
  * Ensured documented limits take precedence over display-name heuristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->