### PR TITLE
Fix tool continuations dying after an earlier recovery in the same turn

### DIFF
--- a/src/stream/client-transcript.ts
+++ b/src/stream/client-transcript.ts
@@ -1,0 +1,72 @@
+/**
+ * Client transcript identity for one Cursor turn.
+ *
+ * Two histories exist while a turn runs and they are not the same thing:
+ *
+ * - the **wire history** (`completedTurns` + `currentTurn`) is what we send upstream. Recovery
+ *   rewrites it: a full-history rebuild folds the in-flight turn into completed history, and a
+ *   checkpoint continuation replaces the current turn with a synthetic one.
+ * - the **client transcript** is what pi will send us on the next request. Recovery never changes
+ *   it, because pi never saw the recovery.
+ *
+ * Every staleness and recovery decision belongs to the client transcript: mid-pause snapshots,
+ * checkpoint metadata, bridge-collision fingerprints, and the in-flight turn `planRecovery`
+ * matches tool results against. Recording wire history there instead is what made a bridge loss
+ * after any earlier recovery unrecoverable — the wire turn is only a suffix of pi's turn, so exact
+ * tool-id matching could never succeed again for the rest of the session.
+ */
+import type { ClientTranscript, ParsedTurn } from "./types.js";
+
+export type { ClientTranscript } from "./types.js";
+
+export function liveTranscript(completedTurns: ParsedTurn[]): ClientTranscript {
+  return { kind: "live", completedTurns };
+}
+
+export function recoveredTranscript(
+  completedTurns: ParsedTurn[],
+  inFlightTurn: ParsedTurn,
+): ClientTranscript {
+  return { kind: "recovered", completedTurns, inFlightTurn };
+}
+
+/**
+ * The turn pi will report as completed once this stream finishes.
+ *
+ * `live` means the wire current turn *is* pi's in-flight turn, so it stands alone. `recovered`
+ * means the wire turn is synthetic and only carries the steps produced since recovery, so pi's
+ * turn is the recorded one extended by those steps. The synthetic turn's user text is a recovery
+ * wrapper pi never sent and is deliberately dropped.
+ */
+export function clientInFlightTurn(
+  transcript: ClientTranscript,
+  wireCurrentTurn: ParsedTurn,
+): ParsedTurn {
+  if (transcript.kind === "live") return wireCurrentTurn;
+  const base = transcript.inFlightTurn;
+  return { ...base, steps: [...base.steps, ...wireCurrentTurn.steps] };
+}
+
+/** Completed history from pi's point of view once this stream finishes. */
+export function clientCompletedHistory(
+  transcript: ClientTranscript,
+  wireCurrentTurn: ParsedTurn,
+): ParsedTurn[] {
+  return [...transcript.completedTurns, clientInFlightTurn(transcript, wireCurrentTurn)];
+}
+
+/**
+ * Fold a synthetic wire turn into the transcript.
+ *
+ * Called wherever recovery replaces the wire current turn, so steps that turn already produced
+ * stay attributed to pi's in-flight turn instead of being forgotten.
+ */
+export function withSyntheticCurrentTurn(
+  transcript: ClientTranscript,
+  wireCurrentTurn: ParsedTurn,
+): ClientTranscript {
+  return recoveredTranscript(
+    transcript.completedTurns,
+    clientInFlightTurn(transcript, wireCurrentTurn),
+  );
+}

--- a/src/stream/message-parsing.ts
+++ b/src/stream/message-parsing.ts
@@ -382,7 +382,9 @@ export function parseMessages(
     if (currentTurn.steps.length === 0 || isToolContinuation) {
       userText = currentTurn.userText;
       userImages = currentTurn.userImages ?? [];
-      if (toolCallSteps.length > 0) inFlightTurn = stripInFlightResults(currentTurn);
+      // Results are kept: this turn is fingerprinted against the completed turn pi will replay
+      // next request, which carries them. Recovery strips them itself where it needs to.
+      if (toolCallSteps.length > 0) inFlightTurn = stripTurnRuntimeState(currentTurn);
       if (hasAnyToolResults) {
         toolResults = toolCallSteps.filter(isToolCallStepWithResult).map((step) => ({
           toolCallId: step.toolCallId,

--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -20,13 +20,11 @@ import {
   ExecClientMessageSchema,
   McpResultSchema,
   McpSuccessSchema,
-  type McpToolDefinition,
 } from "../proto/agent_pb.js";
 import {
   createConnectFrameParser,
   frameConnectMessage,
   parseConnectEndStream,
-  type BridgeHandle,
   type ConnectFrameDesyncDiagnostics,
 } from "../client/bridge.js";
 import type { CursorModelParameter } from "../client/cursor-wire.js";
@@ -38,6 +36,13 @@ export type {
 
 import { processServerMessage } from "./server-messages.js";
 import { createThinkingTagFilter } from "./thinking-filter.js";
+import {
+  clientCompletedHistory,
+  clientInFlightTurn,
+  liveTranscript,
+  recoveredTranscript,
+  withSyntheticCurrentTurn,
+} from "./client-transcript.js";
 import {
   contextToCursorChatCompletionRequest,
   nativeRequestParameterError,
@@ -214,11 +219,12 @@ export { getCursorAgentUrl } from "./config.js";
 import type {
   ActiveBridge,
   ChatCompletionRequest,
-  CheckpointRef,
+  ClientTranscript,
   CursorNativeStreamConfig,
   CursorNativeStreamOptions,
   IdleRestartContext,
   NativeStreamAttemptInput,
+  NativeStreamInput,
   NativeStreamWriter,
   ParsedImageContent,
   ParsedMessages,
@@ -245,8 +251,13 @@ export type {
 
 export const __testInternals = {
   activeBridges,
+  clientCompletedHistory,
+  clientInFlightTurn,
   conversationStates,
   createStreamIdleWatchdog,
+  liveTranscript,
+  recoveredTranscript,
+  withSyntheticCurrentTurn,
   canBlindIdleRestart,
   canRecoverAfterTransportLoss,
   clearStoredMidPauseMetadata,
@@ -568,6 +579,7 @@ async function handleCursorNativeRequest(
             convKey,
             sessionId,
             completedTurns: turns,
+            clientTranscript: activeBridge.clientTranscript,
             maxMode,
             cursorModelParameters: body.cursor_model_parameters ?? [],
             getAccessToken,
@@ -635,6 +647,7 @@ async function handleCursorNativeRequest(
         convKey,
         completedTurns: turns,
         currentTurn: recoveredCurrentTurn,
+        clientTranscript: recoveredTranscript(turns, inFlightTurn ?? recoveredCurrentTurn),
         writer,
         options,
         requestId,
@@ -690,6 +703,7 @@ async function handleCursorNativeRequest(
         convKey,
         completedTurns: rebuiltCompletedTurns,
         currentTurn: recoveredCurrentTurn,
+        clientTranscript: recoveredTranscript(turns, inFlightTurn ?? decision.inFlightTurn),
         writer,
         options,
         requestId,
@@ -821,6 +835,7 @@ async function handleCursorNativeRequest(
     convKey,
     completedTurns: turns,
     currentTurn,
+    clientTranscript: liveTranscript(turns),
     writer,
     options,
     requestId,
@@ -833,25 +848,26 @@ async function handleCursorNativeRequest(
   });
 }
 
-function writeNativeStream(
-  bridge: BridgeHandle,
-  heartbeatTimer: ReturnType<typeof setInterval>,
-  blobStore: Map<string, Uint8Array>,
-  mcpTools: McpToolDefinition[],
-  _model: Model<Api>,
-  modelId: string,
-  bridgeKey: string,
-  convKey: string,
-  completedTurns: ParsedTurn[],
-  currentTurn: ParsedTurn,
-  writer: NativeStreamWriter,
-  options?: CursorNativeStreamOptions,
-  requestId?: string,
-  idleRetry?: StreamIdleRetryController,
-  streamIdleTimeoutMs = resolveStreamIdleTimeoutMs(process.env.PI_CURSOR_STREAM_IDLE_TIMEOUT_MS),
-  checkpointRef: CheckpointRef = { current: null },
-  preservedMidPauseExecs: PendingExec[] = [],
-): void {
+function writeNativeStream(input: NativeStreamInput): void {
+  const {
+    bridge,
+    heartbeatTimer,
+    blobStore,
+    mcpTools,
+    modelId,
+    bridgeKey,
+    convKey,
+    completedTurns,
+    currentTurn,
+    clientTranscript,
+    writer,
+    options,
+    requestId,
+    idleRetry,
+    streamIdleTimeoutMs = resolveStreamIdleTimeoutMs(process.env.PI_CURSOR_STREAM_IDLE_TIMEOUT_MS),
+    checkpointRef = { current: null },
+    preservedMidPauseExecs = [],
+  } = input;
   debugLog("native.stream.start", {
     requestId,
     bridgeKey,
@@ -887,9 +903,10 @@ function writeNativeStream(
   // rest, so the pause is deferred until the whole chunk has been parsed.
   let pauseRequested = false;
   let cachedHistoryFingerprint: string | undefined;
-  // Completed turns are fixed for the life of a stream, so this is hashed at most once.
+  // pi's completed turns, not the wire history: the request path compares this against a fresh
+  // parse of the client's messages. Fixed for the life of a stream, so hashed at most once.
   const historyFingerprint = () =>
-    (cachedHistoryFingerprint ??= fingerprintCompletedTurns(completedTurns));
+    (cachedHistoryFingerprint ??= fingerprintCompletedTurns(clientTranscript.completedTurns));
   const idleWatchdog = createStreamIdleWatchdog({
     timeoutMs: streamIdleTimeoutMs,
     onTimeout: () => {
@@ -925,7 +942,7 @@ function writeNativeStream(
         convKey,
         checkpointRef.current,
         blobStore,
-        completedTurns,
+        clientTranscript,
         currentTurn,
         emittedExecs.length > 0 ? emittedExecs : preservedMidPauseExecs,
       );
@@ -1016,7 +1033,7 @@ function writeNativeStream(
       convKey,
       checkpointRef.current,
       blobStore,
-      completedTurns,
+      clientTranscript,
       currentTurn,
       emittedExecs.length > 0 ? emittedExecs : preservedMidPauseExecs,
     );
@@ -1092,7 +1109,7 @@ function writeNativeStream(
         stored,
         latestCheckpoint: checkpointRef.current,
         blobStore,
-        completedTurns,
+        transcript: clientTranscript,
         pendingExecs: emittedExecs,
         convKey,
       });
@@ -1106,8 +1123,7 @@ function writeNativeStream(
           stored,
           checkpointRef.current,
           blobStore,
-          completedTurns,
-          currentTurn,
+          clientCompletedHistory(clientTranscript, currentTurn),
           convKey,
         );
         debugLog("native.stream.checkpoint_committed", { requestId, convKey, stored });
@@ -1159,7 +1175,7 @@ function writeNativeStream(
                 stored,
                 checkpointRef.current,
                 blobStore,
-                completedTurns,
+                clientTranscript,
                 emittedExecs,
                 convKey,
               );
@@ -1186,6 +1202,7 @@ function writeNativeStream(
               currentTurn,
               checkpointRef,
               state,
+              clientTranscript,
               historyFingerprint: historyFingerprint(),
             });
             debugLog("native.stream.tool_call_pause", {
@@ -1321,7 +1338,7 @@ function writeNativeStream(
           stored,
           latestCheckpoint: checkpointRef.current,
           blobStore,
-          completedTurns,
+          transcript: clientTranscript,
           pendingExecs: emittedExecs,
           convKey,
         });
@@ -1377,7 +1394,7 @@ function writeNativeStream(
             convKey,
             checkpointRef.current,
             blobStore,
-            completedTurns,
+            clientTranscript,
             currentTurn,
             emittedExecs.length > 0 ? emittedExecs : preservedMidPauseExecs,
           );
@@ -1404,7 +1421,7 @@ function writeNativeStream(
           stored,
           latestCheckpoint: checkpointRef.current,
           blobStore,
-          completedTurns,
+          transcript: clientTranscript,
           pendingExecs: emittedExecs,
           convKey,
         });
@@ -1435,8 +1452,7 @@ function writeNativeStream(
             stored,
             checkpointRef.current,
             blobStore,
-            completedTurns,
-            currentTurn,
+            clientCompletedHistory(clientTranscript, currentTurn),
             convKey,
           );
           debugLog("native.stream.checkpoint_committed", { requestId, convKey, stored });
@@ -1450,7 +1466,7 @@ function writeNativeStream(
         stored,
         latestCheckpoint: checkpointRef.current,
         blobStore,
-        completedTurns,
+        transcript: clientTranscript,
         pendingExecs: emittedExecs,
         convKey,
       });
@@ -1479,6 +1495,7 @@ interface ResumeContext {
   convKey: string;
   sessionId: string | undefined;
   completedTurns: ParsedTurn[];
+  clientTranscript: ClientTranscript;
   maxMode: boolean;
   cursorModelParameters: CursorModelParameter[];
   getAccessToken?: (options?: { forceRefresh?: boolean }) => Promise<string>;
@@ -1501,6 +1518,7 @@ function handleNativeToolResultResume(
     convKey,
     sessionId,
     completedTurns,
+    clientTranscript,
     maxMode,
     cursorModelParameters,
     getAccessToken,
@@ -1562,6 +1580,7 @@ function handleNativeToolResultResume(
       mcpTools,
       pendingExecs,
       currentTurn,
+      clientTranscript,
       checkpointRef,
       state: pausedState,
       historyFingerprint,
@@ -1580,7 +1599,7 @@ function handleNativeToolResultResume(
         stored,
         checkpointRef.current,
         blobStore,
-        completedTurns,
+        clientTranscript,
         [...pendingExecs],
         convKey,
       );
@@ -1631,8 +1650,11 @@ function handleNativeToolResultResume(
       const decision = planRecovery({
         stored,
         toolResults,
-        completedTurns,
-        inFlightTurn: stripInFlightResults(currentTurn),
+        completedTurns: clientTranscript.completedTurns,
+        // pi's in-flight turn, not the bridge's. After any earlier recovery the bridge turn holds
+        // only the steps since that recovery, so matching it against the tool results pi replays
+        // could never succeed again for the rest of the turn.
+        inFlightTurn: stripInFlightResults(clientInFlightTurn(clientTranscript, currentTurn)),
         rebuildReason: "synthesized_after_idle",
         sessionId,
         requestId: requestId ?? "native-tool-idle-retry",
@@ -1680,6 +1702,7 @@ function handleNativeToolResultResume(
           convKey,
           completedTurns: rebuiltCompletedTurns,
           currentTurn: recoveredCurrentTurn,
+          clientTranscript: withSyntheticCurrentTurn(clientTranscript, currentTurn),
           writer,
           options,
           requestId,
@@ -1755,6 +1778,7 @@ function handleNativeToolResultResume(
         convKey,
         completedTurns,
         currentTurn: recoveredCurrentTurn,
+        clientTranscript: withSyntheticCurrentTurn(clientTranscript, currentTurn),
         writer,
         options,
         requestId,
@@ -1770,28 +1794,28 @@ function handleNativeToolResultResume(
     },
   };
 
-  writeNativeStream(
+  writeNativeStream({
     bridge,
     heartbeatTimer,
     blobStore,
     mcpTools,
-    model,
     modelId,
     bridgeKey,
     convKey,
     completedTurns,
     currentTurn,
+    clientTranscript,
     writer,
     options,
     requestId,
     idleRetry,
-    resumeIdleTimeoutMs,
+    streamIdleTimeoutMs: resumeIdleTimeoutMs,
     // Same bridge, so the same checkpoint cell: frames that landed during the pause stay visible.
     checkpointRef,
     // A timeout after Cursor receives the tool result still needs the original pause
     // snapshot so recovery can safely recreate that continuation.
-    pendingExecs,
-  );
+    preservedMidPauseExecs: pendingExecs,
+  });
 }
 
 // ── Request handling ──
@@ -1858,6 +1882,7 @@ function startNativeStreamWithIdleRetries(input: NativeStreamAttemptInput): void
   let blobStore = input.blobStore;
   let completedTurns = input.completedTurns;
   let currentTurn = input.currentTurn;
+  let clientTranscript = input.clientTranscript;
 
   const controller: StreamIdleRetryController = {
     currentAttempt: 1,
@@ -1907,6 +1932,10 @@ function startNativeStreamWithIdleRetries(input: NativeStreamAttemptInput): void
           requestBytes = payload.requestBytes;
           blobStore = payload.blobStore;
           completedTurns = context.completedTurns;
+          const clientHistory = clientCompletedHistory(clientTranscript, context.currentTurn);
+          // The continuation turn is ours, not pi's: fold the steps produced so far into pi's
+          // in-flight turn so later snapshots still describe the transcript pi will replay.
+          clientTranscript = withSyntheticCurrentTurn(clientTranscript, context.currentTurn);
           currentTurn = { userText: continueText, steps: [] };
           const stored = conversationStates.get(input.convKey);
           if (stored) {
@@ -1914,8 +1943,7 @@ function startNativeStreamWithIdleRetries(input: NativeStreamAttemptInput): void
               stored,
               context.latestCheckpoint,
               context.blobStore,
-              context.completedTurns,
-              context.currentTurn,
+              clientHistory,
               input.convKey,
             );
           }
@@ -1944,23 +1972,23 @@ function startNativeStreamWithIdleRetries(input: NativeStreamAttemptInput): void
         const { bridge, heartbeatTimer } = startBridge(accessToken, requestBytes, {
           bridgeKey: input.bridgeKey,
         });
-        writeNativeStream(
+        writeNativeStream({
           bridge,
           heartbeatTimer,
           blobStore,
-          input.mcpTools,
-          input.model,
-          input.modelId,
-          input.bridgeKey,
-          input.convKey,
+          mcpTools: input.mcpTools,
+          modelId: input.modelId,
+          bridgeKey: input.bridgeKey,
+          convKey: input.convKey,
           completedTurns,
           currentTurn,
-          input.writer,
-          input.options,
-          input.requestId,
-          controller,
-          input.streamIdleTimeoutMs,
-        );
+          clientTranscript,
+          writer: input.writer,
+          options: input.options,
+          requestId: input.requestId,
+          idleRetry: controller,
+          streamIdleTimeoutMs: input.streamIdleTimeoutMs,
+        });
       };
 
       // First attempt is synchronous. Later attempts force-refresh credentials when possible.

--- a/src/stream/session-state.ts
+++ b/src/stream/session-state.ts
@@ -39,8 +39,10 @@ import {
   MAX_CHECKPOINT_BYTES,
   MAX_CONVERSATION_BLOB_BYTES,
 } from "./tuning.js";
+import { clientCompletedHistory } from "./client-transcript.js";
 import type {
   ChatCompletionRequest,
+  ClientTranscript,
   OpenAIMessage,
   ParsedTurn,
   StoredConversation,
@@ -258,15 +260,18 @@ export function mergeBlobStore(
   stored.lastAccessMs = Date.now();
 }
 
+/**
+ * `completedHistory` is pi's history once this turn lands, not the wire history. After a recovery
+ * the two differ, and recording the wire one makes the next turn discard a healthy checkpoint and
+ * rotate the conversation. See ./client-transcript.ts.
+ */
 export function commitStoredCheckpoint(
   stored: StoredConversation,
   checkpointBytes: Uint8Array,
   blobStore: Map<string, Uint8Array>,
-  completedTurns: ParsedTurn[],
-  currentTurn: ParsedTurn,
+  completedHistory: ParsedTurn[],
   convKey?: string,
 ): void {
-  const completedHistory = [...completedTurns, currentTurn];
   mergeBlobStore(stored, blobStore);
   stored.checkpoint = checkpointBytes;
   stored.checkpointSource = "upstream";
@@ -281,8 +286,8 @@ export function persistAbortedConversationState(
   convKey: string,
   latestCheckpoint: Uint8Array | null,
   blobStore: Map<string, Uint8Array>,
-  completedTurns: ParsedTurn[],
-  currentTurn: ParsedTurn,
+  transcript: ClientTranscript,
+  wireCurrentTurn: ParsedTurn,
   pendingToolCalls: Array<{ toolCallId: string; toolName: string }> = [],
 ): void {
   const stored = conversationStates.get(convKey);
@@ -296,16 +301,15 @@ export function persistAbortedConversationState(
       stored,
       latestCheckpoint,
       blobStore,
-      completedTurns,
+      transcript,
       pendingToolCalls,
       convKey,
     );
     debugLog("native.stream.abort_state_saved", {
       convKey,
       hasCheckpoint: !!latestCheckpoint,
-      completedTurnCount: completedTurns.length,
+      completedTurnCount: transcript.completedTurns.length,
       pendingToolCallIds: pendingToolCalls.map((call) => call.toolCallId),
-      currentTurn,
     });
     return;
   }
@@ -318,8 +322,7 @@ export function persistAbortedConversationState(
       stored,
       latestCheckpoint,
       blobStore,
-      completedTurns,
-      currentTurn,
+      clientCompletedHistory(transcript, wireCurrentTurn),
       convKey,
     );
   } else {
@@ -333,8 +336,7 @@ export function persistAbortedConversationState(
   debugLog("native.stream.abort_state_saved", {
     convKey,
     hasCheckpoint: !!latestCheckpoint,
-    completedTurnCount: completedTurns.length,
-    currentTurn,
+    completedTurnCount: transcript.completedTurns.length,
   });
 }
 
@@ -342,11 +344,12 @@ export function commitStoredCheckpointMidPause(
   stored: StoredConversation,
   checkpointBytes: Uint8Array | null,
   blobStore: Map<string, Uint8Array>,
-  completedTurns: ParsedTurn[],
+  transcript: ClientTranscript,
   pendingToolCalls: Array<{ toolCallId: string; toolName: string }>,
   convKey?: string,
 ): void {
   mergeBlobStore(stored, blobStore);
+  const completedTurns = transcript.completedTurns;
   const completedHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
   if (checkpointBytes) {
     stored.checkpoint = checkpointBytes;
@@ -376,7 +379,7 @@ export interface HandleBridgeCloseMidPauseInput {
   stored: StoredConversation | undefined;
   latestCheckpoint: Uint8Array | null;
   blobStore: Map<string, Uint8Array>;
-  completedTurns: ParsedTurn[];
+  transcript: ClientTranscript;
   pendingExecs: Array<{ toolCallId: string; toolName: string }>;
   convKey?: string;
 }
@@ -389,7 +392,7 @@ export function handleBridgeCloseMidPause(input: HandleBridgeCloseMidPauseInput)
     input.stored,
     input.latestCheckpoint,
     input.blobStore,
-    input.completedTurns,
+    input.transcript,
     input.pendingExecs,
     input.convKey,
   );

--- a/src/stream/types.ts
+++ b/src/stream/types.ts
@@ -132,6 +132,11 @@ export interface ParsedMessages {
   userImages: ParsedImageContent[];
   turns: ParsedTurn[];
   toolResults: ToolResultInfo[];
+  /**
+   * The turn pi is still working on, tool results included, exactly as pi will replay it as a
+   * completed turn next request. Recovery strips the results itself when it needs the pre-result
+   * shape; fingerprints need them.
+   */
   inFlightTurn?: ParsedTurn;
 }
 
@@ -170,6 +175,17 @@ export interface CheckpointRef {
   current: Uint8Array | null;
 }
 
+/**
+ * pi's view of the turn in flight, as opposed to the wire history sent upstream.
+ *
+ * `live` means the wire current turn is pi's own turn. `recovered` means recovery replaced the
+ * wire turn with a synthetic one, so pi's turn is `inFlightTurn` extended by whatever the
+ * synthetic turn produces. Behaviour lives in ./client-transcript.ts.
+ */
+export type ClientTranscript =
+  | { kind: "live"; completedTurns: ParsedTurn[] }
+  | { kind: "recovered"; completedTurns: ParsedTurn[]; inFlightTurn: ParsedTurn };
+
 export interface ActiveBridge {
   bridge: BridgeHandle;
   heartbeatTimer: ReturnType<typeof setInterval>;
@@ -180,6 +196,8 @@ export interface ActiveBridge {
   currentTurn: ParsedTurn;
   checkpointRef: CheckpointRef;
   state: StreamState;
+  /** pi's view of this turn, which recovery must not rewrite. See ./client-transcript.ts. */
+  clientTranscript: ClientTranscript;
   /** Fingerprint of the completed turns this bridge was parked on; guards against key collisions. */
   historyFingerprint: string;
 }
@@ -254,6 +272,29 @@ export interface StreamIdleRetryController {
   restart(nextAttempt: number, context: IdleRestartContext): boolean;
 }
 
+export interface NativeStreamInput {
+  bridge: BridgeHandle;
+  heartbeatTimer: ReturnType<typeof setInterval>;
+  blobStore: Map<string, Uint8Array>;
+  mcpTools: McpToolDefinition[];
+  modelId: string;
+  bridgeKey: string;
+  convKey: string;
+  /** History sent upstream. Recovery rewrites this; it is not pi's transcript. */
+  completedTurns: ParsedTurn[];
+  currentTurn: ParsedTurn;
+  clientTranscript: ClientTranscript;
+  writer: NativeStreamWriter;
+  options?: CursorNativeStreamOptions;
+  requestId?: string;
+  idleRetry?: StreamIdleRetryController;
+  streamIdleTimeoutMs?: number;
+  /** Shared so a checkpoint delivered during a tool pause survives the resume boundary. */
+  checkpointRef?: CheckpointRef;
+  /** Pause snapshot to retain when this stream is a resume that never emits its own execs. */
+  preservedMidPauseExecs?: PendingExec[];
+}
+
 export interface NativeStreamAttemptInput {
   accessToken: string;
   requestBytes: Uint8Array;
@@ -265,6 +306,7 @@ export interface NativeStreamAttemptInput {
   convKey: string;
   completedTurns: ParsedTurn[];
   currentTurn: ParsedTurn;
+  clientTranscript: ClientTranscript;
   writer: NativeStreamWriter;
   options?: CursorNativeStreamOptions;
   requestId?: string;

--- a/tests/abort-recovery.test.ts
+++ b/tests/abort-recovery.test.ts
@@ -37,7 +37,7 @@ describe("aborted native streams", () => {
       convKey,
       checkpoint,
       blobStore,
-      completedTurns,
+      __testInternals.liveTranscript(completedTurns),
       currentTurn,
     );
 
@@ -55,10 +55,13 @@ describe("aborted native streams", () => {
     const blobStore = new Map([["blob-1", new Uint8Array([4, 5, 6])]]);
     __testInternals.conversationStates.set(convKey, stored);
 
-    __testInternals.persistAbortedConversationState(convKey, null, blobStore, [], {
-      userText: "continue the task",
-      steps: [],
-    });
+    __testInternals.persistAbortedConversationState(
+      convKey,
+      null,
+      blobStore,
+      __testInternals.liveTranscript([]),
+      { userText: "continue the task", steps: [] },
+    );
 
     expect(stored.checkpoint).toBeNull();
     expect(stored.blobStore.get("blob-1")).toEqual(new Uint8Array([4, 5, 6]));
@@ -75,7 +78,7 @@ describe("aborted native streams", () => {
       convKey,
       checkpoint,
       new Map(),
-      completedTurns,
+      __testInternals.liveTranscript(completedTurns),
       {
         userText: "run a command",
         steps: [{ kind: "toolCall", toolCallId: "call-1", toolName: "shell", arguments: {} }],

--- a/tests/client-transcript.test.ts
+++ b/tests/client-transcript.test.ts
@@ -1,0 +1,215 @@
+import { create, toBinary } from "@bufbuild/protobuf";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ConversationStateStructureSchema } from "../src/proto/agent_pb.js";
+import {
+  clientCompletedHistory,
+  clientInFlightTurn,
+  liveTranscript,
+  withSyntheticCurrentTurn,
+} from "../src/stream/client-transcript.js";
+import { fingerprintCompletedTurns, planRecovery } from "../src/stream/recovery.js";
+import {
+  commitStoredCheckpointMidPause,
+  conversationStates,
+  discardStaleCheckpointIfNeeded,
+} from "../src/stream/session-state.js";
+import type {
+  ParsedToolCallStep,
+  ParsedTurn,
+  StoredConversation,
+  ToolResultInfo,
+} from "../src/stream/types.js";
+
+function toolCall(id: string, result?: string): ParsedToolCallStep {
+  return {
+    kind: "toolCall",
+    toolCallId: id,
+    toolName: "bash",
+    arguments: { command: `run ${id}` },
+    ...(result ? { result: { content: result, isError: false } } : {}),
+  };
+}
+
+function storedConversation(partial: Partial<StoredConversation> = {}): StoredConversation {
+  return {
+    conversationId: "conv-1",
+    checkpoint: null,
+    sessionScoped: true,
+    sessionId: "session-1",
+    blobStore: new Map(),
+    lastAccessMs: Date.now(),
+    ...partial,
+  };
+}
+
+describe("client transcript identity across recovery", () => {
+  beforeEach(() => {
+    conversationStates.clear();
+  });
+
+  // The production failure: a long agent turn takes several tool rounds, loses its bridge once,
+  // continues from a checkpoint — which replaces the wire turn with a synthetic one — and then
+  // loses the bridge again. The second loss must still be recoverable.
+  it("recovers a bridge loss that follows an earlier checkpoint continuation", () => {
+    const convKey = "conv-key";
+    const stored = storedConversation();
+    conversationStates.set(convKey, stored);
+
+    // Rounds 1 and 2 ran on the original bridge, so pi's turn holds both.
+    const wireTurnBeforeLoss: ParsedTurn = {
+      userText: "solve the obligation",
+      steps: [toolCall("call-a"), toolCall("call-b")],
+    };
+    let transcript = liveTranscript([]);
+
+    // Checkpoint continuation after the first bridge loss: the wire turn is replaced by a
+    // synthetic one, so from here the wire only ever sees round 3.
+    transcript = withSyntheticCurrentTurn(transcript, wireTurnBeforeLoss);
+    const syntheticWireTurn: ParsedTurn = {
+      userText: "[continue]",
+      steps: [toolCall("call-c")],
+    };
+
+    commitStoredCheckpointMidPause(
+      stored,
+      null,
+      new Map(),
+      transcript,
+      [{ toolCallId: "call-c", toolName: "bash" }],
+      convKey,
+    );
+
+    // pi answers every outstanding call and replays its own view of the turn.
+    const toolResults: ToolResultInfo[] = [
+      { toolCallId: "call-a", content: "a" },
+      { toolCallId: "call-b", content: "b" },
+      { toolCallId: "call-c", content: "c" },
+    ];
+    const clientInFlight: ParsedTurn = {
+      userText: "solve the obligation",
+      steps: [toolCall("call-a", "a"), toolCall("call-b", "b"), toolCall("call-c", "c")],
+    };
+
+    const decision = planRecovery({
+      stored,
+      toolResults,
+      completedTurns: transcript.completedTurns,
+      inFlightTurn: clientInFlightTurn(transcript, syntheticWireTurn),
+      sessionId: "session-1",
+      requestId: "req-1",
+      convKey,
+    });
+
+    expect(decision.kind).toBe("rebuild_full_history");
+    if (decision.kind === "rebuild_full_history") {
+      expect(decision.inFlightTurn.steps.map((s) => (s as ParsedToolCallStep).toolCallId)).toEqual([
+        "call-a",
+        "call-b",
+        "call-c",
+      ]);
+    }
+
+    // The regression this guards: matching the bridge's own turn instead of pi's sees only the
+    // round that survived the continuation, and every later loss in the turn is fatal.
+    const wireOnly = planRecovery({
+      stored,
+      toolResults,
+      completedTurns: [],
+      inFlightTurn: syntheticWireTurn,
+      sessionId: "session-1",
+      requestId: "req-1",
+      convKey,
+    });
+    expect(wireOnly.kind).toBe("skip");
+    if (wireOnly.kind === "skip") expect(wireOnly.reason).toBe("pending_tool_call_mismatch");
+
+    expect(clientInFlight.steps).toHaveLength(3);
+  });
+
+  it("snapshots pi's completed-turn count after a full-history rebuild", () => {
+    const convKey = "conv-key";
+    const stored = storedConversation();
+    conversationStates.set(convKey, stored);
+
+    const completed: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const clientInFlight: ParsedTurn = { userText: "now", steps: [toolCall("call-a", "a")] };
+
+    // A rebuild folds pi's in-flight turn into the wire history, so wire completed turns are one
+    // ahead of pi's for the rest of the turn.
+    const transcript = withSyntheticCurrentTurn(
+      { kind: "recovered", completedTurns: completed, inFlightTurn: clientInFlight },
+      { userText: "[recovered]", steps: [toolCall("call-b")] },
+    );
+
+    commitStoredCheckpointMidPause(
+      stored,
+      null,
+      new Map(),
+      transcript,
+      [{ toolCallId: "call-b", toolName: "bash" }],
+      convKey,
+    );
+
+    expect(stored.midPauseTurnCount).toBe(completed.length);
+    expect(stored.midPauseHistoryFingerprint).toBe(fingerprintCompletedTurns(completed));
+
+    const decision = planRecovery({
+      stored,
+      toolResults: [
+        { toolCallId: "call-a", content: "a" },
+        { toolCallId: "call-b", content: "b" },
+      ],
+      completedTurns: completed,
+      inFlightTurn: clientInFlightTurn(transcript, { userText: "", steps: [] }),
+      sessionId: "session-1",
+      requestId: "req-1",
+      convKey,
+    });
+    expect(decision.kind).toBe("rebuild_full_history");
+  });
+
+  it("keeps the checkpoint usable on the next turn after a recovery", () => {
+    const convKey = "conv-key";
+    const completed: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const clientInFlight: ParsedTurn = {
+      userText: "now",
+      steps: [toolCall("call-a", "a")],
+    };
+    const transcript = withSyntheticCurrentTurn(
+      { kind: "recovered", completedTurns: completed, inFlightTurn: clientInFlight },
+      { userText: "[recovered]", steps: [] },
+    );
+    const syntheticWireTurn: ParsedTurn = {
+      userText: "[recovered]",
+      steps: [{ kind: "assistantText", text: "done" }],
+    };
+
+    const history = clientCompletedHistory(transcript, syntheticWireTurn);
+    const stored = storedConversation({
+      checkpoint: toBinary(
+        ConversationStateStructureSchema,
+        create(ConversationStateStructureSchema, {}),
+      ),
+      checkpointSource: "upstream",
+      checkpointTurnCount: history.length,
+      checkpointHistoryFingerprint: fingerprintCompletedTurns(history),
+    });
+    conversationStates.set(convKey, stored);
+
+    // pi's next request replays the finished turn: original user text, its tool call and result,
+    // then the assistant text produced after recovery. The recovery wrapper text is not pi's.
+    const replayed: ParsedTurn[] = [
+      ...completed,
+      {
+        userText: "now",
+        steps: [toolCall("call-a", "a"), { kind: "assistantText", text: "done" }],
+      },
+    ];
+    expect(fingerprintCompletedTurns(replayed)).toBe(stored.checkpointHistoryFingerprint);
+
+    discardStaleCheckpointIfNeeded(stored, replayed, "req-2", convKey);
+    expect(stored.checkpoint).not.toBeNull();
+    expect(stored.conversationId).toBe("conv-1");
+  });
+});

--- a/tests/transport-recovery.test.ts
+++ b/tests/transport-recovery.test.ts
@@ -261,23 +261,22 @@ describe("native stream terminal cleanup", () => {
       },
     };
     const heartbeatTimer = setInterval(() => {}, 60_000);
-    __testInternals.writeNativeStream(
+    __testInternals.writeNativeStream({
       bridge,
       heartbeatTimer,
-      new Map(),
-      [],
-      {} as never,
-      "claude-4.5-sonnet",
-      "bridge-cleanup",
-      "conv-cleanup",
-      [],
-      { userText: "hi", steps: [] },
-      writer as never,
-      signal ? ({ signal } as never) : undefined,
-      "req-cleanup",
-      undefined,
-      0,
-    );
+      blobStore: new Map(),
+      mcpTools: [],
+      modelId: "claude-4.5-sonnet",
+      bridgeKey: "bridge-cleanup",
+      convKey: "conv-cleanup",
+      completedTurns: [],
+      currentTurn: { userText: "hi", steps: [] },
+      clientTranscript: __testInternals.liveTranscript([]),
+      writer: writer as never,
+      options: signal ? ({ signal } as never) : undefined,
+      requestId: "req-cleanup",
+      streamIdleTimeoutMs: 0,
+    });
     return {
       calls,
       get endCalls() {
@@ -385,23 +384,21 @@ describe("completed-turn connection close", () => {
     };
     const heartbeatTimer = setInterval(() => {}, 60_000);
 
-    __testInternals.writeNativeStream(
+    __testInternals.writeNativeStream({
       bridge,
       heartbeatTimer,
-      new Map(),
-      [],
-      {} as never,
-      "claude-4.5-sonnet",
-      "bridge-key",
-      "conv-key",
-      [],
-      { userText: "hi", steps: [] },
-      writer as never,
-      undefined,
-      "req-1",
-      undefined,
-      0,
-    );
+      blobStore: new Map(),
+      mcpTools: [],
+      modelId: "claude-4.5-sonnet",
+      bridgeKey: "bridge-key",
+      convKey: "conv-key",
+      completedTurns: [],
+      currentTurn: { userText: "hi", steps: [] },
+      clientTranscript: __testInternals.liveTranscript([]),
+      writer: writer as never,
+      requestId: "req-1",
+      streamIdleTimeoutMs: 0,
+    });
 
     onData(
       updateFrame({


### PR DESCRIPTION
## What breaks

A turn that loses its bridge more than once can never recover the second time. Every later tool result in that turn is rejected with `pending_tool_call_mismatch`, and the session dies with:

```
Cursor tool continuation was lost because the live upstream bridge is no longer available.
[diagnostic: hadStoredCheckpoint=false bridgeKeyPrefix=... skipReason=pending_tool_call_mismatch]
```

Observed on long autonomous agent sessions against `grok-4.6`: **11 of 28 runs died this way**, always after a checkpoint continuation had already recovered an earlier loss in the same turn. Once a turn enters this state it cannot leave it — every subsequent tool round fails identically, so multi-hour sessions lose all their work.

## Why

Two histories exist while a turn runs, and the code treats them as one:

- the **wire history** (`completedTurns` + `currentTurn`) is what we send upstream. Recovery rewrites it: `rebuild_full_history` folds the in-flight turn into completed history, and a checkpoint continuation replaces the current turn with a synthetic one holding only the steps produced since that continuation.
- the **client transcript** is what pi replays on the next request. Recovery never changes it, because pi never saw the recovery.

`handleNativeToolResultResume`'s idle/transport `restart()` matched `planRecovery` against the bridge's own `currentTurn`:

```ts
inFlightTurn: stripInFlightResults(currentTurn),
```

After any earlier recovery that turn is a strict *suffix* of pi's in-flight turn. `validateExactToolResultMatch` then compares a handful of tool ids against every result pi replayed, so it can never succeed again for the rest of the turn.

Mid-pause snapshots and checkpoint metadata had the same confusion from the other side: after a rebuild the wire completed-turn count is one ahead of pi's, so the next request trips `midpause_turn_count_mismatch` and `completed_turn_count_mismatch`, clearing the snapshot and rotating the conversation.

A journal captured at the moment of failure shows it directly — one user turn, 38 tool calls in flight, `midPauseHistoryFingerprint` = sha256("") = `fingerprintCompletedTurns([])`, pending `[call-33]`, and pi replaying all 38 results.

## The change

`ClientTranscript` makes pi's view explicit and carries it through every stream attempt, resume, continuation and rebuild:

```ts
export type ClientTranscript =
  | { kind: "live"; completedTurns: ParsedTurn[] }
  | { kind: "recovered"; completedTurns: ParsedTurn[]; inFlightTurn: ParsedTurn };
```

`live` means the wire current turn *is* pi's own turn; `recovered` means it is synthetic and pi's turn is the recorded one extended by its steps. Recovery matching, mid-pause snapshots, checkpoint metadata and the bridge-collision fingerprint all read from it, so wire history can no longer be passed where pi's transcript is meant — `commitStoredCheckpointMidPause`, `handleBridgeCloseMidPause` and `persistAbortedConversationState` now take a `ClientTranscript` rather than a bare `ParsedTurn[]`.

`parseMessages` keeps tool results on the returned in-flight turn, since that turn is fingerprinted against the completed turn pi replays; `planRecovery` already strips them where it needs the pre-result shape.

Also here because it made the above safe to write: `writeNativeStream` takes an options object rather than eighteen positional arguments, and drops its unused `model` parameter.

## Tests

`tests/client-transcript.test.ts` reproduces the production sequence — two tool rounds, a checkpoint continuation, a third round, then a bridge loss — and pins both sides: matching pi's transcript rebuilds, and matching the bridge's own turn still skips with `pending_tool_call_mismatch`. Two further tests cover the snapshot turn-count after a rebuild and checkpoint survival on the next turn.

`npm run check` passes (typecheck, lint, format, security, proto, 189 tests, legacy scripts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation recovery after connection interruptions, preserving in-progress turns, tool calls, and results.
  * Maintained checkpoint integrity across retries, pauses, aborts, and subsequent turns.
  * Preserved pending tool-call information when recovering incomplete turns.

* **Tests**
  * Added coverage for transcript recovery, checkpoint continuity, bridge loss, and transport recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->