### PR TITLE
fix: evict oldest blobs at the entry bound instead of failing the turn

### DIFF
--- a/src/stream/server-messages.ts
+++ b/src/stream/server-messages.ts
@@ -71,7 +71,7 @@ import {
   MAX_ACTIVE_BLOB_ENTRIES,
   MAX_INDIVIDUAL_BLOB_BYTES,
 } from "./tuning.js";
-import { markBlobMiss } from "./session-state.js";
+import { markBlobMiss, trimBlobStore } from "./session-state.js";
 import type { PendingExec, StreamState } from "./types.js";
 import { setLastStreamEvent } from "../diagnostics/diagnostics.js";
 
@@ -297,7 +297,21 @@ function handleKvMessage(
       throw new Error(`Cursor blob exceeds the ${MAX_INDIVIDUAL_BLOB_BYTES} byte per-blob limit`);
     }
     if (!blobStore.has(blobIdKey) && blobStore.size >= MAX_ACTIVE_BLOB_ENTRIES) {
-      throw new Error(`Cursor blob store exceeds the ${MAX_ACTIVE_BLOB_ENTRIES} entry limit`);
+      // Turn blobs run a couple of KB, so the entry bound is reached at a
+      // fraction of a percent of the byte budget and the byte trim never fires.
+      // Failing the write here failed the whole turn, and since the store is
+      // only ever added to, every later turn in that conversation failed the
+      // same way. Evict oldest-first instead: a blob Cursor still references
+      // comes back as a getBlobArgs miss, which invalidates the checkpoint and
+      // rebuilds from Pi's history — one costlier turn rather than a dead
+      // conversation, the same trade the byte trim already makes.
+      const evicted = trimBlobStore(blobStore, MAX_ACTIVE_BLOB_BYTES, MAX_ACTIVE_BLOB_ENTRIES - 1);
+      debugLog("kv.blob_store_evicted", {
+        removed: evicted.removed,
+        totalBytes: evicted.totalBytes,
+        entries: blobStore.size,
+        maxEntries: MAX_ACTIVE_BLOB_ENTRIES,
+      });
     }
     let totalBytes = blobData.byteLength;
     for (const [key, value] of blobStore) {

--- a/src/stream/session-state.ts
+++ b/src/stream/session-state.ts
@@ -36,6 +36,7 @@ import {
 } from "./run-journal.js";
 import {
   CONVERSATION_TTL_MS,
+  MAX_ACTIVE_BLOB_ENTRIES,
   MAX_CHECKPOINT_BYTES,
   MAX_CONVERSATION_BLOB_BYTES,
 } from "./tuning.js";
@@ -217,15 +218,17 @@ export function discardStaleCheckpointIfNeeded(
 export function trimBlobStore(
   store: Map<string, Uint8Array>,
   maxBytes = MAX_CONVERSATION_BLOB_BYTES,
+  maxEntries = MAX_ACTIVE_BLOB_ENTRIES,
 ): { removed: number; totalBytes: number } {
   let totalBytes = 0;
   for (const value of store.values()) totalBytes += value.byteLength;
-  if (totalBytes <= maxBytes) return { removed: 0, totalBytes };
+  const withinBudget = () => totalBytes <= maxBytes && store.size <= maxEntries;
+  if (withinBudget()) return { removed: 0, totalBytes };
 
   let removed = 0;
   // Map iteration order is insertion order — drop oldest blobs first.
   for (const key of store.keys()) {
-    if (totalBytes <= maxBytes) break;
+    if (withinBudget()) break;
     const value = store.get(key);
     if (!value) continue;
     totalBytes -= value.byteLength;
@@ -252,7 +255,9 @@ export function mergeBlobStore(
     debugLog("conversation.blob_store_trimmed", {
       removed: trimmed.removed,
       totalBytes: trimmed.totalBytes,
+      entries: stored.blobStore.size,
       maxBytes: MAX_CONVERSATION_BLOB_BYTES,
+      maxEntries: MAX_ACTIVE_BLOB_ENTRIES,
     });
   }
   stored.lastAccessMs = Date.now();

--- a/src/stream/tuning.ts
+++ b/src/stream/tuning.ts
@@ -33,6 +33,10 @@ export const DEFAULT_MIDPAUSE_REBUILD_MAX_AGE_MS = 15 * 60 * 1000;
 /** Soft cap on retained blob bytes per conversation (images + turn blobs). */
 export const MAX_CONVERSATION_BLOB_BYTES = 128 * 1024 * 1024;
 export const MAX_ACTIVE_BLOB_BYTES = MAX_CONVERSATION_BLOB_BYTES;
+// Entry bound, evicted oldest-first alongside the byte bound. Turn blobs run a
+// couple of KB, so this is reached long before the byte cap on any conversation
+// that lives for a few hundred tool calls; it bounds Map overhead, and matches
+// the number of blobs the run journal is willing to persist.
 export const MAX_ACTIVE_BLOB_ENTRIES = 512;
 export const MAX_INDIVIDUAL_BLOB_BYTES = 32 * 1024 * 1024;
 

--- a/tests/durability.test.ts
+++ b/tests/durability.test.ts
@@ -10,6 +10,7 @@ import {
   mergeBlobStore,
   trimBlobStore,
 } from "../src/stream/session-state.js";
+import { MAX_ACTIVE_BLOB_ENTRIES } from "../src/stream/tuning.js";
 import type { OpenAIMessage, StoredConversation } from "../src/stream/types.js";
 
 const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
@@ -154,5 +155,29 @@ describe("blob store eviction order", () => {
 
     expect(stored.blobStore.has("system")).toBe(true);
     expect(stored.blobStore.has("turn-1")).toBe(false);
+  });
+
+  it("bounds the store by entries, not only by bytes", () => {
+    const stored = storedConversation();
+    // Realistically sized turn blobs: the entry bound is reached while the byte
+    // total is still a rounding error against MAX_CONVERSATION_BLOB_BYTES, so a
+    // byte-only trim leaves the store growing without limit.
+    for (let i = 0; i < MAX_ACTIVE_BLOB_ENTRIES + 40; i++) {
+      mergeBlobStore(stored, new Map([[`turn-${i}`, new Uint8Array(1500).fill(i % 256)]]));
+    }
+
+    expect(stored.blobStore.size).toBe(MAX_ACTIVE_BLOB_ENTRIES);
+    expect(stored.blobStore.has("turn-0")).toBe(false);
+    expect(stored.blobStore.has(`turn-${MAX_ACTIVE_BLOB_ENTRIES + 39}`)).toBe(true);
+  });
+
+  it("leaves a store inside both bounds untouched", () => {
+    const stored = storedConversation();
+    for (let i = 0; i < 10; i++) {
+      mergeBlobStore(stored, new Map([[`turn-${i}`, new Uint8Array(8).fill(i)]]));
+    }
+
+    expect(trimBlobStore(stored.blobStore).removed).toBe(0);
+    expect(stored.blobStore.size).toBe(10);
   });
 });

--- a/tests/idle-progress.test.ts
+++ b/tests/idle-progress.test.ts
@@ -79,7 +79,7 @@ describe("idle progress classification", () => {
     expect(executions).toHaveLength(0);
   });
 
-  it("rejects active blob stores that exceed their entry bound", () => {
+  it("evicts the oldest active blob instead of failing the write at the entry bound", () => {
     const store = new Map<string, Uint8Array>();
     for (let i = 0; i < MAX_ACTIVE_BLOB_ENTRIES; i++) {
       store.set(i.toString(16).padStart(4, "0"), new Uint8Array([1]));
@@ -105,17 +105,24 @@ describe("idle progress classification", () => {
       totalTokens: 0,
       turnEnded: false,
     };
-    expect(() =>
+    const frames: Uint8Array[] = [];
+    expect(
       processServerMessage(
         message,
         store,
         [],
-        () => {},
+        (frame) => frames.push(frame),
         state,
         () => {},
         () => {},
       ),
-    ).toThrow(/entry limit/);
+    ).toBe(true);
+    // The write is acknowledged, the store stays at its bound, and the blob that
+    // was evicted to make room is the oldest one rather than the incoming one.
+    expect(frames).toHaveLength(1);
+    expect(store.size).toBe(MAX_ACTIVE_BLOB_ENTRIES);
+    expect(store.has("0000")).toBe(false);
+    expect(store.has("ffff")).toBe(true);
   });
 
   it("treats tokenDelta and toolCallCompleted as watchdog progress", () => {


### PR DESCRIPTION
## Problem

`setBlobArgs` throws once the active blob store holds `MAX_ACTIVE_BLOB_ENTRIES` (512) distinct blobs:

```ts
if (!blobStore.has(blobIdKey) && blobStore.size >= MAX_ACTIVE_BLOB_ENTRIES) {
  throw new Error(`Cursor blob store exceeds the ${MAX_ACTIVE_BLOB_ENTRIES} entry limit`);
}
```

Of the three blob bounds, only the byte bound has an eviction path (`trimBlobStore`, oldest-first); the entry bound throws. Real turn blobs run a couple of KB, so 512 entries is reached at well under 1% of the 128 MiB byte budget and the byte trim never fires.

Because the store is only ever added to, the failure is permanent rather than per-turn. A session accruing a handful of blobs per tool call dies with `Cursor blob store exceeds the 512 entry limit`, and every subsequent turn in that conversation fails identically — the conversation cannot be continued at all.

## Fix

- `trimBlobStore` takes an entry budget beside its byte budget, and stops once the store is inside both.
- The `setBlobArgs` handler evicts oldest-first to make room instead of throwing. The per-blob and total-byte guards still throw; only the entry bound became an eviction.
- `mergeBlobStore` inherits the entry bound through the default, so the retained per-conversation store is capped at the same number of blobs `serializeConversationJournal` is already willing to persist — memory and journal now agree.

Two existing properties make this the same trade the byte trim already makes, rather than a new failure mode:

- Insertion order approximates LRU, because `mergeBlobStore` delete-then-sets every blob a build touches. The system-prompt blob that every checkpoint points at is refreshed on each build, so it is not the first casualty.
- An evicted blob Cursor still references returns as a `getBlobArgs` miss, which `markBlobMiss` already handles by invalidating the checkpoint and rebuilding from the Pi transcript. That costs one more expensive turn instead of ending the conversation.

## Tests

- `tests/idle-progress.test.ts` — the entry-bound case now asserts the write is acknowledged, the store stays at its bound, and the evicted entry is the oldest one rather than the incoming one (it previously asserted the throw).
- `tests/durability.test.ts` — realistically sized blobs past the bound leave the store at 512 with the oldest dropped and the newest kept; a store inside both bounds is left untouched.

Both new assertions fail against `main` (`expected 552 to be 512`, and `Cursor blob store exceeds the 512 entry limit`).

`npm run check` passes: 196 tests, plus typecheck, lint, format, security, proto and the legacy scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blob storage now automatically removes the oldest entries when the configured entry limit is reached.
  - New entries are preserved when older entries are evicted.

- **Bug Fixes**
  - Blob writes no longer fail solely because the entry-count limit has been reached.
  - Storage continues to respect both entry-count and total-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->