### PR TITLE
fix: answer an undecodable exec with a throw, and stop heartbeats from hiding a parked turn

### DIFF
--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -142,7 +142,8 @@ import {
   canBlindIdleRestart,
   canRecoverAfterTransportLoss,
   createStreamIdleWatchdog,
-  interactionUpdateCountsAsProgress,
+  DEFAULT_STREAM_PARK_TIMEOUT_MS,
+  interactionUpdateProgress,
   resolveH2ConnectTimeoutMs,
   resolveH2IdleTimeoutMs,
   resolveMidPauseRebuildMaxAgeMs,
@@ -153,7 +154,7 @@ import {
 export {
   canBlindIdleRestart,
   canRecoverAfterTransportLoss,
-  interactionUpdateCountsAsProgress,
+  interactionUpdateProgress,
   resolveActiveBridgeTtlMs,
   resolveH2ConnectTimeoutMs,
   resolveH2IdleTimeoutMs,
@@ -266,7 +267,7 @@ export const __testInternals = {
   discardStaleCheckpointIfNeeded,
   fingerprintCompletedTurns,
   getOrHydrateConversation,
-  interactionUpdateCountsAsProgress,
+  interactionUpdateProgress,
   redactForDebug,
   resolveH2ConnectTimeoutMs,
   resolveH2IdleTimeoutMs,
@@ -909,6 +910,14 @@ function writeNativeStream(
   // rest, so the pause is deferred until the whole chunk has been parsed.
   let pauseRequested = false;
   let cachedHistoryFingerprint: string | undefined;
+  // An exec Cursor asked for and we could not answer. The run is waiting on a reply
+  // it will never recognize, so heartbeats stop counting as progress and the watchdog
+  // switches to the shorter park deadline until real work resumes.
+  let parkedExecCase: string | undefined;
+  // A park deadline can only be shorter than the silence deadline, and an explicitly
+  // disabled watchdog stays disabled.
+  const parkTimeoutMs =
+    streamIdleTimeoutMs <= 0 ? 0 : Math.min(streamIdleTimeoutMs, DEFAULT_STREAM_PARK_TIMEOUT_MS);
   // Completed turns are fixed for the life of a stream, so this is hashed at most once.
   const historyFingerprint = () =>
     (cachedHistoryFingerprint ??= fingerprintCompletedTurns(completedTurns));
@@ -939,9 +948,9 @@ function writeNativeStream(
         hasCheckpoint: !!checkpointRef.current,
       });
       setLastIdleTimeout({
-        timeoutMs: streamIdleTimeoutMs,
+        timeoutMs: parkedExecCase === undefined ? streamIdleTimeoutMs : parkTimeoutMs,
         attempt,
-        event: "idle_timeout",
+        event: parkedExecCase === undefined ? "idle_timeout" : "park_timeout",
       });
       persistAbortedConversationState(
         convKey,
@@ -1019,12 +1028,14 @@ function writeNativeStream(
         }
       }
       writer.error(
-        formatStreamIdleTimeoutMessage(
-          streamIdleTimeoutMs,
-          finalAttempt,
-          maxRetries,
-          emittedUserVisibleContent,
-        ),
+        parkedExecCase === undefined
+          ? formatStreamIdleTimeoutMessage(
+              streamIdleTimeoutMs,
+              finalAttempt,
+              maxRetries,
+              emittedUserVisibleContent,
+            )
+          : formatStreamParkMessage(parkedExecCase, parkTimeoutMs),
         "error",
         state,
       );
@@ -1146,7 +1157,7 @@ function writeNativeStream(
     (messageBytes) => {
       try {
         const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-        const madeProgress = processServerMessage(
+        const progress = processServerMessage(
           serverMessage,
           blobStore,
           mcpTools,
@@ -1224,8 +1235,20 @@ function writeNativeStream(
             checkpointRef.current = checkpointBytes;
             debugLog("native.stream.checkpoint_buffered", { requestId, convKey, checkpointBytes });
           },
+          (execCase) => {
+            parkedExecCase = execCase ?? "unknown";
+            debugLog("native.stream.exec_park", { requestId, bridgeKey, convKey, execCase });
+            idleWatchdog.setTimeoutMs(parkTimeoutMs);
+            idleWatchdog.reset();
+          },
         );
-        if (madeProgress) {
+        if (progress === "work") {
+          if (parkedExecCase !== undefined) {
+            parkedExecCase = undefined;
+            idleWatchdog.setTimeoutMs(streamIdleTimeoutMs);
+          }
+          idleWatchdog.reset();
+        } else if (progress === "liveness" && parkedExecCase === undefined) {
           idleWatchdog.reset();
         }
       } catch (err) {
@@ -1882,6 +1905,14 @@ function formatStreamIdleTimeoutMessage(
   const tunePart =
     " Tune PI_CURSOR_STREAM_IDLE_TIMEOUT_MS / PI_CURSOR_RESUME_IDLE_TIMEOUT_MS if long reasoning turns are expected.";
   return `${base}${retryPart}.${partialPart}${tunePart}`;
+}
+
+function formatStreamParkMessage(execCase: string, timeoutMs: number): string {
+  return (
+    `Cursor parked the turn on exec case "${execCase}", which this build cannot answer ` +
+    `(agent.proto is behind Cursor's wire protocol). The exec was failed with a throw and the ` +
+    `run still did no work for ${timeoutMs}ms. Run /cursor.doctor for the recorded drift signal.`
+  );
 }
 
 function startNativeStreamWithIdleRetries(input: NativeStreamAttemptInput): void {

--- a/src/stream/server-messages.ts
+++ b/src/stream/server-messages.ts
@@ -23,7 +23,9 @@ import {
   DeleteRejectedSchema,
   DeleteResultSchema,
   DiagnosticsResultSchema,
+  ExecClientControlMessageSchema,
   ExecClientMessageSchema,
+  ExecClientThrowSchema,
   FetchErrorSchema,
   FetchResultSchema,
   GetBlobResultSchema,
@@ -66,28 +68,27 @@ import { recordDriftSignal, recordUnknownFields } from "./drift.js";
 import { handleInteractionQuery } from "./interaction-query.js";
 import { decodeMcpArgsMap } from "./request-build.js";
 import {
-  interactionUpdateCountsAsProgress,
+  interactionUpdateProgress,
   MAX_ACTIVE_BLOB_BYTES,
   MAX_ACTIVE_BLOB_ENTRIES,
   MAX_INDIVIDUAL_BLOB_BYTES,
+  type StreamProgress,
 } from "./tuning.js";
 import { markBlobMiss, trimBlobStore } from "./session-state.js";
 import type { PendingExec, StreamState } from "./types.js";
 import { setLastStreamEvent } from "../diagnostics/diagnostics.js";
 
 /**
- * Returns true when this message represents forward progress / upstream liveness
- * for the stream idle watchdog:
- *   - non-empty `textDelta` / `thinkingDelta`
- *   - `tokenDelta` (long reasoning often emits only these for minutes)
- *   - `toolCallCompleted`
- *   - any handled `execServerMessage` (MCP exec **or** native-tool reject reply)
- *   - `conversationCheckpointUpdate` with an `onCheckpoint` sink
- *   - handled KV get/set blob round-trips
- *   - handled interaction queries (e.g. WebFetch approval)
+ * Classifies a server message for the stream idle watchdog.
  *
- * Returns false only for empty text deltas, unhandled KV/exec/interaction cases,
- * and other noise. A true hang is silence — not token accounting or reject loops.
+ * `work` — the run is moving: non-empty `textDelta` / `thinkingDelta`,
+ * `tokenDelta` (long reasoning often emits only these for minutes), tool-call
+ * events, any answered `execServerMessage` (MCP exec **or** native-tool reject),
+ * answered interaction queries, KV blob round-trips, checkpoints.
+ *
+ * `liveness` — a heartbeat. The socket is healthy; the turn may still be parked.
+ *
+ * `none` — empty deltas, unanswered exec/KV/interaction cases, other noise.
  */
 export function processServerMessage(
   msg: AgentServerMessage,
@@ -98,7 +99,8 @@ export function processServerMessage(
   onText: (text: string, isThinking?: boolean) => void,
   onMcpExec: (exec: PendingExec) => void,
   onCheckpoint?: (checkpointBytes: Uint8Array) => void,
-): boolean {
+  onExecUnanswerable?: (execCase: string | undefined) => void,
+): StreamProgress {
   const msgCase = msg.message.case;
   debugLog("server_message", { msgCase, msg });
   recordUnknownFields(`AgentServerMessage.${msgCase ?? "none"}`, msg);
@@ -111,21 +113,21 @@ export function processServerMessage(
       const delta = update.message.value.text || "";
       if (delta) {
         onText(delta, false);
-        return interactionUpdateCountsAsProgress(updateCase, true);
+        return interactionUpdateProgress(updateCase, true);
       }
-      return false;
+      return "none";
     }
     if (updateCase === "thinkingDelta") {
       const delta = update.message.value.text || "";
       if (delta) {
         onText(delta, true);
-        return interactionUpdateCountsAsProgress(updateCase, true);
+        return interactionUpdateProgress(updateCase, true);
       }
-      return false;
+      return "none";
     }
     if (updateCase === "tokenDelta") {
       state.outputTokens += update.message.value.tokens ?? 0;
-      return interactionUpdateCountsAsProgress(updateCase);
+      return interactionUpdateProgress(updateCase);
     }
     if (updateCase === "toolCallCompleted") {
       const completed = update.message.value as any;
@@ -148,24 +150,27 @@ export function processServerMessage(
           errorUnknown: value?.$unknown,
         });
       }
-      return interactionUpdateCountsAsProgress(updateCase);
+      return interactionUpdateProgress(updateCase);
     }
     if (updateCase === "turnEnded") {
       // Cursor closes the HTTP/2 connection right after this. Recorded so the close is
       // finalized as a completed turn instead of retried as a failure (upstream #3).
       state.turnEnded = true;
-      return true;
+      return "work";
     }
-    // Liveness cases (heartbeat, toolCallStarted, partialToolCall, ...) are already defined by
-    // interactionUpdateCountsAsProgress; reuse it rather than keeping a second list here.
-    if (interactionUpdateCountsAsProgress(updateCase)) return true;
+    // Remaining cases (heartbeat, toolCallStarted, partialToolCall, ...) are already
+    // classified by interactionUpdateProgress; reuse it rather than keeping a second list.
+    const progress = interactionUpdateProgress(updateCase);
+    if (progress !== "none") return progress;
     // Unrecognized update cases are informational rather than stranding — the
     // stream keeps flowing — but they are the first sign our schema is behind.
     recordDriftSignal("interaction_update", updateCase);
-    return false;
+    return "none";
   }
   if (msgCase === "kvServerMessage") {
-    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame);
+    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame)
+      ? "work"
+      : "none";
   }
   if (msgCase === "execServerMessage") {
     const execMsg = msg.message.value as ExecServerMessage;
@@ -182,8 +187,9 @@ export function processServerMessage(
     if (!handled) {
       setLastStreamEvent(`exec_unanswered:${String(execCase ?? "unknown")}`);
       recordDriftSignal("exec_message", execCase);
+      onExecUnanswerable?.(execCase);
     }
-    return handled;
+    return handled ? "work" : "none";
   }
   if (msgCase === "interactionQuery") {
     const query = msg.message.value as InteractionQuery;
@@ -214,7 +220,7 @@ export function processServerMessage(
         `Unsupported Cursor interaction query ${result.queryCase ?? "unknown"} was rejected`,
       );
     }
-    return true;
+    return "work";
   }
   if (msgCase === "execServerControlMessage") {
     const control = msg.message.value as { message?: { case?: string } };
@@ -222,7 +228,7 @@ export function processServerMessage(
     debugLog("native.exec_server_control", { controlCase });
     lifecycleLog("exec_server_control", { controlCase });
     // Abort notices are informational; the stream may continue or end separately.
-    return controlCase === "abort";
+    return controlCase === "abort" ? "work" : "none";
   }
   if (msgCase === "conversationCheckpointUpdate") {
     const stateStructure = msg.message.value as ConversationStateStructure;
@@ -231,16 +237,16 @@ export function processServerMessage(
     }
     if (onCheckpoint) {
       onCheckpoint(toBinary(ConversationStateStructureSchema, stateStructure));
-      return true;
+      return "work";
     }
-    return false;
+    return "none";
   }
 
   // Nothing matched: Cursor sent a server message this build has no branch for.
   // Nobody answers it, so if the run was waiting on it the turn will park until
   // the idle watchdog fires — record it so the timeout is explainable.
   recordDriftSignal("server_message", msgCase);
-  return false;
+  return "none";
 }
 
 function sendKvResponse(
@@ -669,11 +675,61 @@ function handleExecMessageInner(
     return true;
   }
 
-  // Fail closed: a guessed result case with an MCP payload is indistinguishable
-  // from a successful reply for a future destructive exec and can strand the run.
-  console.error(`[cursor-provider] UNHANDLED exec case: "${execCase}". Bridge may stall.`);
+  // No result shape is known for an exec case this build has no branch for, and
+  // guessing one is unsafe: a fabricated success is indistinguishable from having
+  // actually performed a destructive operation. But silence is not the alternative
+  // — Cursor parks the run on the unanswered exec id and heartbeats forever.
+  // ExecClientThrow answers any exec by id without claiming a result, so the model
+  // sees a failed tool instead of a dead stream.
+  console.error(`[cursor-provider] UNHANDLED exec case: "${execCase}". Answering with a throw.`);
+  lifecycleLog("exec_unknown_shape", {
+    execCase: execCase ?? "unknown",
+    unknownFields: describeUnknownFields(execMsg),
+  });
   setLastStreamEvent(`unhandled_exec:${String(execCase ?? "unknown")}`);
+  sendExecThrow(
+    execMsg,
+    `Pi's Cursor provider has no handler for exec case "${execCase ?? "unknown"}" ` +
+      `(wire drift: this build's agent.proto is behind Cursor). ${REJECT_REASON}`,
+    sendFrame,
+  );
   return false;
+}
+
+/**
+ * Field numbers, wire types and sizes of protobuf fields our schema lacks — the
+ * only evidence available for identifying a new Cursor exec case, and safe to
+ * keep in the always-on lifecycle log because it carries no payload content.
+ */
+function describeUnknownFields(message: unknown): string {
+  const unknown = (
+    message as { $unknown?: readonly { no: number; wireType: number; data: Uint8Array }[] }
+  ).$unknown;
+  if (!unknown || unknown.length === 0) return "";
+  return unknown
+    .map((field) => `${field.no}:wt${field.wireType}:${field.data?.byteLength ?? 0}b`)
+    .join(",");
+}
+
+/**
+ * The one reply that fits every exec: `ExecClientThrow` is keyed by exec id, not
+ * by exec case, so it releases a parked run whose request we cannot understand.
+ */
+function sendExecThrow(
+  execMsg: ExecServerMessage,
+  error: string,
+  sendFrame: (data: Uint8Array) => void,
+): void {
+  const control = create(ExecClientControlMessageSchema, {
+    message: {
+      case: "throw",
+      value: create(ExecClientThrowSchema, { id: (execMsg as any).id, error }),
+    },
+  });
+  const clientMessage = create(AgentClientMessageSchema, {
+    message: { case: "execClientControlMessage", value: control },
+  });
+  sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
 }
 
 function sendExecResult(
@@ -696,4 +752,5 @@ function sendExecResult(
 export const __testInternals = {
   nativeToolRejectReason,
   handleExecMessageInner,
+  describeUnknownFields,
 };

--- a/src/stream/tuning.ts
+++ b/src/stream/tuning.ts
@@ -11,17 +11,21 @@ export const CONVERSATION_TTL_MS = 30 * 60 * 1000;
 
 export const DEFAULT_ACTIVE_BRIDGE_TTL_MS = 60 * 60 * 1000;
 
-// Safety net against permanent hangs: if the upstream stream produces NO progress
-// of any kind for this long, the watchdog recovers/retries or ends the turn with a
-// clear error instead of parking forever. This is silence-based — every server
-// signal (textDelta, thinkingDelta, tokenDelta, tool-call events, thinkingCompleted,
-// heartbeat, summary, answered interaction/exec) counts as progress and resets it
-// (see interactionUpdateCountsAsProgress), and it is paused during tool execution —
-// so long reasoning turns and slow tools are unaffected. It only fires on a genuine
-// park (unanswered exec, dropped/silent upstream). Set the env vars to 0 to disable.
-// 3 minutes: long pure-thinking stretches without tokenDelta still need headroom,
-// while a true silent park should not hang forever.
+// Safety net against permanent hangs: if the upstream stream produces no progress
+// for this long, the watchdog recovers/retries or ends the turn with a clear error
+// instead of parking forever. Real work (textDelta, thinkingDelta, tokenDelta,
+// tool-call events, answered interaction/exec) always resets it, and it is paused
+// during tool execution — so long reasoning turns and slow tools are unaffected.
+// Set the env vars to 0 to disable. 3 minutes: long pure-thinking stretches without
+// tokenDelta still need headroom, while a true silent park should not hang forever.
 export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 180_000;
+
+// A stream parked on an exec we could not answer is not slow, it is finished: Cursor
+// waits for a reply that will never arrive while its heartbeats keep the connection
+// alive. Liveness stops counting as progress once that happens (see StreamProgress),
+// and this shorter deadline gives the generic ExecClientThrow answer time to unpark
+// the run before the turn is failed.
+export const DEFAULT_STREAM_PARK_TIMEOUT_MS = 45_000;
 
 export const DEFAULT_RESUME_IDLE_TIMEOUT_MS = 180_000;
 
@@ -114,29 +118,44 @@ export function resolveH2IdleTimeoutMs(envValue?: string): number {
 }
 
 /**
- * Whether an interaction-update case should reset the stream idle watchdog.
- * tokenDelta is treated as upstream liveness (long reasoning turns emit it
- * without text for minutes at a time).
+ * What a server message says about the stream.
+ *
+ * `work` is the run moving: tokens, tool calls, answered execs, checkpoints.
+ * `liveness` is the connection breathing while the run itself may be stuck —
+ * a heartbeat proves the socket, not the turn. `none` is noise.
+ *
+ * The distinction exists because a park is not silent: Cursor keeps heartbeating
+ * a run that is waiting for an exec reply we never sent, which made a
+ * silence-only watchdog unable to ever fire (a Grok session sat parked for 90
+ * minutes on an unknown exec case in 2026-08).
  */
-export function interactionUpdateCountsAsProgress(
+export type StreamProgress = "none" | "liveness" | "work";
+
+/**
+ * How an interaction-update case should be treated by the stream idle watchdog.
+ * tokenDelta is work: long reasoning turns emit it without text for minutes at a
+ * time, and it only flows while the model is actually generating.
+ */
+export function interactionUpdateProgress(
   updateCase: string | undefined,
   hasNonEmptyText = false,
-): boolean {
-  if (updateCase === "textDelta" || updateCase === "thinkingDelta") return hasNonEmptyText;
-  if (updateCase === "tokenDelta") return true;
-  if (updateCase === "toolCallCompleted") return true;
-  if (updateCase === "toolCallStarted") return true;
-  if (updateCase === "partialToolCall") return true;
-  if (updateCase === "toolCallDelta") return true;
-  if (updateCase === "thinkingCompleted") return true;
-  if (updateCase === "heartbeat") return true;
+): StreamProgress {
+  if (updateCase === "textDelta" || updateCase === "thinkingDelta")
+    return hasNonEmptyText ? "work" : "none";
+  if (updateCase === "heartbeat") return "liveness";
+  if (updateCase === "tokenDelta") return "work";
+  if (updateCase === "toolCallCompleted") return "work";
+  if (updateCase === "toolCallStarted") return "work";
+  if (updateCase === "partialToolCall") return "work";
+  if (updateCase === "toolCallDelta") return "work";
+  if (updateCase === "thinkingCompleted") return "work";
   if (
     updateCase === "summary" ||
     updateCase === "summaryStarted" ||
     updateCase === "summaryCompleted"
   )
-    return true;
-  return false;
+    return "work";
+  return "none";
 }
 
 /** Whether a blind full-request restart is safe given already-streamed content. */
@@ -173,11 +192,13 @@ export function createStreamIdleWatchdog(options: { timeoutMs: number; onTimeout
   pause(): void;
   resume(): void;
   clear(): void;
+  setTimeoutMs(timeoutMs: number): void;
 } {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let started = false;
   let paused = false;
   let fired = false;
+  let timeoutMs = options.timeoutMs;
 
   const clear = () => {
     if (timer) clearTimeout(timer);
@@ -186,12 +207,12 @@ export function createStreamIdleWatchdog(options: { timeoutMs: number; onTimeout
 
   const arm = () => {
     clear();
-    if (options.timeoutMs <= 0 || paused || fired) return;
+    if (timeoutMs <= 0 || paused || fired) return;
     timer = setTimeout(() => {
       timer = undefined;
       fired = true;
       options.onTimeout();
-    }, options.timeoutMs);
+    }, timeoutMs);
     (timer as { unref?: () => void }).unref?.();
   };
 
@@ -214,6 +235,11 @@ export function createStreamIdleWatchdog(options: { timeoutMs: number; onTimeout
       if (fired) return;
       paused = false;
       arm();
+    },
+    setTimeoutMs(next: number) {
+      if (next === timeoutMs) return;
+      timeoutMs = next;
+      if (started) arm();
     },
     clear,
   };

--- a/tests/idle-progress.test.ts
+++ b/tests/idle-progress.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { create } from "@bufbuild/protobuf";
+import { create, fromBinary } from "@bufbuild/protobuf";
 import {
+  AgentClientMessageSchema,
   AgentServerMessageSchema,
   ExecServerMessageSchema,
   HeartbeatUpdateSchema,
@@ -11,13 +12,15 @@ import {
   PartialToolCallUpdateSchema,
   SetBlobArgsSchema,
   ToolCallStartedUpdateSchema,
+  type ExecClientControlMessage,
+  type ExecClientThrow,
 } from "../src/proto/agent_pb.js";
 import { processServerMessage } from "../src/stream/server-messages.js";
 import type { StreamState } from "../src/stream/types.js";
 import {
   __testInternals,
   canBlindIdleRestart,
-  interactionUpdateCountsAsProgress,
+  interactionUpdateProgress,
   resolveH2ConnectTimeoutMs,
   resolveH2IdleTimeoutMs,
   resolveResumeIdleTimeoutMs,
@@ -74,9 +77,48 @@ describe("idle progress classification", () => {
         () => {},
         (execution) => executions.push(execution),
       ),
-    ).toBe(true);
+    ).toBe("work");
     expect(frames).toHaveLength(1);
     expect(executions).toHaveLength(0);
+  });
+
+  it("answers an exec case it cannot decode with a throw instead of parking", () => {
+    const message = create(AgentServerMessageSchema, {
+      message: {
+        case: "execServerMessage",
+        value: create(ExecServerMessageSchema, { id: 7, execId: "exec-7" }),
+      },
+    });
+    const state: StreamState = {
+      toolCallIndex: 0,
+      pendingExecs: [],
+      outputTokens: 0,
+      totalTokens: 0,
+      turnEnded: false,
+    };
+    const frames: Uint8Array[] = [];
+    const parked: (string | undefined)[] = [];
+
+    const progress = processServerMessage(
+      message,
+      new Map(),
+      [],
+      (frame) => frames.push(frame),
+      state,
+      () => {},
+      () => {},
+      undefined,
+      (execCase) => parked.push(execCase),
+    );
+
+    expect(progress).toBe("none");
+    expect(parked).toHaveLength(1);
+    expect(frames).toHaveLength(1);
+    const answer = fromBinary(AgentClientMessageSchema, frames[0]!.subarray(5));
+    expect(answer.message.case).toBe("execClientControlMessage");
+    const control = answer.message.value as ExecClientControlMessage;
+    expect(control.message.case).toBe("throw");
+    expect((control.message.value as ExecClientThrow).id).toBe(7);
   });
 
   it("evicts the oldest active blob instead of failing the write at the entry bound", () => {
@@ -116,22 +158,22 @@ describe("idle progress classification", () => {
         () => {},
         () => {},
       ),
-    ).toBe(true);
+    ).toBe("work");
     expect(frames).toHaveLength(1);
     expect(store.size).toBe(MAX_ACTIVE_BLOB_ENTRIES);
     expect(store.has("0000")).toBe(false);
     expect(store.has("ffff")).toBe(true);
   });
 
-  it("treats tokenDelta and toolCallCompleted as watchdog progress", () => {
-    expect(interactionUpdateCountsAsProgress("tokenDelta")).toBe(true);
-    expect(interactionUpdateCountsAsProgress("toolCallCompleted")).toBe(true);
-    expect(interactionUpdateCountsAsProgress("heartbeat")).toBe(true);
-    expect(interactionUpdateCountsAsProgress("thinkingCompleted")).toBe(true);
-    expect(interactionUpdateCountsAsProgress("toolCallStarted")).toBe(true);
+  it("separates real work from a heartbeat that only proves the socket", () => {
+    expect(interactionUpdateProgress("tokenDelta")).toBe("work");
+    expect(interactionUpdateProgress("toolCallCompleted")).toBe("work");
+    expect(interactionUpdateProgress("thinkingCompleted")).toBe("work");
+    expect(interactionUpdateProgress("toolCallStarted")).toBe("work");
+    expect(interactionUpdateProgress("heartbeat")).toBe("liveness");
   });
 
-  it("resets the watchdog for liveness updates the dispatcher receives", () => {
+  it("classifies the liveness updates the dispatcher receives", () => {
     const liveness = [
       { case: "heartbeat" as const, value: create(HeartbeatUpdateSchema, {}) },
       { case: "toolCallStarted" as const, value: create(ToolCallStartedUpdateSchema, {}) },
@@ -151,7 +193,7 @@ describe("idle progress classification", () => {
           value: create(InteractionUpdateSchema, { message }),
         },
       });
-      const madeProgress = processServerMessage(
+      const progress = processServerMessage(
         serverMessage,
         new Map(),
         [],
@@ -160,15 +202,18 @@ describe("idle progress classification", () => {
         () => {},
         () => {},
       );
-      expect([message.case, madeProgress]).toEqual([message.case, true]);
+      expect([message.case, progress]).toEqual([
+        message.case,
+        message.case === "heartbeat" ? "liveness" : "work",
+      ]);
     }
   });
 
   it("requires non-empty text for text/thinking deltas", () => {
-    expect(interactionUpdateCountsAsProgress("textDelta", true)).toBe(true);
-    expect(interactionUpdateCountsAsProgress("textDelta", false)).toBe(false);
-    expect(interactionUpdateCountsAsProgress("thinkingDelta", true)).toBe(true);
-    expect(interactionUpdateCountsAsProgress("thinkingDelta", false)).toBe(false);
+    expect(interactionUpdateProgress("textDelta", true)).toBe("work");
+    expect(interactionUpdateProgress("textDelta", false)).toBe("none");
+    expect(interactionUpdateProgress("thinkingDelta", true)).toBe("work");
+    expect(interactionUpdateProgress("thinkingDelta", false)).toBe("none");
   });
 
   it("blocks blind restarts once user-visible content was streamed", () => {
@@ -225,6 +270,21 @@ describe("disabled idle watchdog", () => {
 });
 
 describe("stream idle watchdog", () => {
+  it("re-arms on a shorter deadline once a park shortens it", async () => {
+    let fired = 0;
+    const watchdog = __testInternals.createStreamIdleWatchdog({
+      timeoutMs: 10_000,
+      onTimeout: () => {
+        fired += 1;
+      },
+    });
+    watchdog.start();
+    watchdog.setTimeoutMs(30);
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    watchdog.clear();
+    expect(fired).toBe(1);
+  });
+
   it("fires after the configured timeout when never reset", async () => {
     let fired = 0;
     const watchdog = __testInternals.createStreamIdleWatchdog({

--- a/tests/request-size.test.ts
+++ b/tests/request-size.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { fromBinary } from "@bufbuild/protobuf";
+import {
+  AgentClientMessageSchema,
+  type ExecClientControlMessage,
+  type ExecClientThrow,
+} from "../src/proto/agent_pb.js";
 import {
   MAX_MCP_TOOL_RESULT_BYTES,
   MAX_MCP_TOOL_TEXT_BYTES,
@@ -160,18 +166,33 @@ describe("native Cursor exec steering", () => {
     );
   });
 
-  it("does not invent a reply for an unknown native exec", () => {
+  it("throws an unknown native exec instead of inventing a result or parking", () => {
     const frames: Uint8Array[] = [];
     const handled = serverMessageInternals.handleExecMessageInner(
-      { message: { case: "futureDestructiveArgs", value: {} } } as never,
+      { id: 12, execId: "exec-12", message: { case: "futureDestructiveArgs", value: {} } } as never,
       [],
       (frame: Uint8Array) => frames.push(frame),
       () => {
         throw new Error("should not execute");
       },
     );
+    // Unhandled: no result was fabricated for a case whose semantics are unknown.
     expect(handled).toBe(false);
-    expect(frames).toHaveLength(0);
+    // Answered anyway: ExecClientThrow is keyed by exec id, so Cursor stops waiting.
+    expect(frames).toHaveLength(1);
+    const answer = fromBinary(AgentClientMessageSchema, frames[0]!.subarray(5));
+    expect(answer.message.case).toBe("execClientControlMessage");
+    const control = answer.message.value as ExecClientControlMessage;
+    expect(control.message.case).toBe("throw");
+    expect((control.message.value as ExecClientThrow).id).toBe(12);
+  });
+
+  it("reports the field numbers of an exec our schema cannot decode", () => {
+    expect(
+      serverMessageInternals.describeUnknownFields({
+        $unknown: [{ no: 28, wireType: 2, data: new Uint8Array(9) }],
+      }),
+    ).toBe("28:wt2:9b");
   });
 });
 

--- a/tests/transport-recovery.test.ts
+++ b/tests/transport-recovery.test.ts
@@ -6,6 +6,8 @@ import { join } from "node:path";
 
 import {
   AgentServerMessageSchema,
+  ExecServerMessageSchema,
+  HeartbeatUpdateSchema,
   InteractionUpdateSchema,
   TextDeltaUpdateSchema,
   TurnEndedUpdateSchema,
@@ -428,6 +430,87 @@ describe("completed-turn connection close", () => {
     clearInterval(heartbeatTimer);
 
     expect(calls).toEqual(["done:stop"]);
+  });
+
+  it("fails a turn parked on an unanswerable exec even while heartbeats keep arriving", async () => {
+    const calls: string[] = [];
+    const written: Uint8Array[] = [];
+    const writer = {
+      output: {} as never,
+      closed: false,
+      start() {},
+      text() {},
+      thinking() {},
+      toolCall() {},
+      done(reason: string) {
+        calls.push(`done:${reason}`);
+        this.closed = true;
+      },
+      error(message: string) {
+        calls.push(`error:${message}`);
+        this.closed = true;
+      },
+    };
+    let onData: (chunk: Buffer) => void = () => {};
+    const bridge = {
+      proc: { kill: () => true },
+      alive: true,
+      lastStderr: () => "",
+      write: (data: Uint8Array) => written.push(data),
+      end: () => {},
+      onData: (cb: (chunk: Buffer) => void) => {
+        onData = cb;
+      },
+      onClose: () => {},
+    };
+    const heartbeatTimer = setInterval(() => {}, 60_000);
+
+    __testInternals.writeNativeStream(
+      bridge,
+      heartbeatTimer,
+      new Map(),
+      [],
+      {} as never,
+      "grok-4.6",
+      "bridge-park",
+      "conv-park",
+      [],
+      { userText: "hi", steps: [] },
+      writer as never,
+      undefined,
+      "req-park",
+      undefined,
+      40,
+    );
+
+    // An exec case this build has no branch for: Cursor waits for a reply forever.
+    onData(
+      frame(
+        toBinary(
+          AgentServerMessageSchema,
+          create(AgentServerMessageSchema, {
+            message: {
+              case: "execServerMessage",
+              value: create(ExecServerMessageSchema, { id: 3, execId: "exec-park" }),
+            },
+          }),
+        ),
+      ),
+    );
+    expect(written).toHaveLength(1);
+
+    // Cursor keeps the connection warm while it waits. Before the park was modelled,
+    // these reset the silence watchdog and the turn hung until the operator noticed.
+    const beats = setInterval(
+      () => onData(updateFrame({ case: "heartbeat", value: create(HeartbeatUpdateSchema, {}) })),
+      10,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    clearInterval(beats);
+    clearInterval(heartbeatTimer);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatch(/^error:Cursor parked the turn on exec case/);
   });
 });
 


### PR DESCRIPTION
## The hang

Cursor's server sends `ExecServerMessage` and waits for a reply keyed by exec id. When the case is one this build's `agent.proto` has no branch for, `handleExecMessageInner` falls through to fail-closed: it logs `UNHANDLED exec case` and sends nothing. Cursor then waits for that reply forever.

The stream is not silent while it waits — the server keeps sending heartbeats — and `interactionUpdateCountsAsProgress` counted a heartbeat as progress, so `DEFAULT_STREAM_IDLE_TIMEOUT_MS` never elapsed. The comment above that constant says the watchdog "only fires on a genuine park (unanswered exec, dropped/silent upstream)", but an unanswered exec is exactly the case it cannot see.

Observed on 2026-08-21 in an autonomous `grok-4.6` session: `exec_server {"execCase":"unknown","handled":false}` alongside `wire_drift {"kind":"unknown_fields","detail":"execServerMessage.payload#28,55","stranding":true}`, then 90 minutes of nothing while TCP showed a healthy keepalive exchange every ~10s. Aborting and retrying reproduced the same park within a minute — the server re-issues the exec, so retry is not a way out.

## The fix

1. **Answer it.** `ExecClientThrow` is addressed by exec id, not by exec case, so it can answer an exec whose semantics we do not know. No result is invented (the original reason for failing closed stands — a fabricated success is indistinguishable from having performed a destructive operation), but the run gets a failed tool instead of a dead stream.
2. **Stop propping up a parked stream.** `processServerMessage` now returns `"work" | "liveness" | "none"` instead of a boolean. Heartbeats are liveness; once an exec goes unanswerable the watchdog switches to a shorter park deadline and liveness no longer resets it, so the turn ends with a message naming the exec case instead of hanging.
3. **Make the next drift identifiable.** The unknown field numbers, wire types and sizes go to the lifecycle log (`exec_unknown_shape`), which is what identifying a new Cursor exec case otherwise takes a packet capture to learn.

## Tests

- `tests/transport-recovery.test.ts` — a stream fed an undecodable exec and then a heartbeat every 10ms fails on the park deadline; before the change the heartbeats held it open indefinitely.
- `tests/idle-progress.test.ts` — the throw answer, and heartbeat classified as liveness rather than work.
- `tests/request-size.test.ts` — an unknown exec is answered with a throw and still reported unhandled.

`npm run check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream idle detection so heartbeats no longer prevent genuine timeout handling.
  * Unsupported execution requests now return a clear error response and fail reliably after the park timeout.
  * Stream diagnostics and timeout errors now distinguish regular idle timeouts from execution parking.

* **Improvements**
  * Added a shorter 45-second parking period for unanswerable execution requests.
  * Normal stream timeouts are restored automatically when work resumes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->