### PR TITLE
fix: preserve named JSON Schema properties when slimming tools

### DIFF
--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -82,7 +82,6 @@ export {
 import {
   buildCursorRequest,
   buildMcpSuccessContent,
-  buildMcpToolDefinitions,
   isIdentityConversationalTurn,
   isTrivialConversationalTurn,
   normalizeToolResultForTransport,
@@ -91,13 +90,13 @@ import {
 export {
   buildCursorRequest,
   isIdentityConversationalTurn,
-  isSlimToolsEnabled,
   isTrivialConversationalTurn,
-  slimOpenAIToolsForCursor,
   summarizeRequestSize,
   type BuildCursorRequestOptions,
 } from "./request-build.js";
 import { hashSystemPrompt } from "./root-prompt.js";
+export { isSlimToolsEnabled, slimOpenAIToolsForCursor } from "./tool-schema.js";
+import { buildMcpToolDefinitions } from "./tool-schema.js";
 export {
   buildRootPromptMessages,
   hashSystemPrompt,

--- a/src/stream/request-build.ts
+++ b/src/stream/request-build.ts
@@ -28,7 +28,6 @@ import {
   McpSuccessSchema,
   McpTextContentSchema,
   McpToolCallSchema,
-  McpToolDefinitionSchema,
   McpToolErrorSchema,
   McpToolResultSchema,
   McpToolResultContentItemSchema,
@@ -52,6 +51,11 @@ import {
   isPromptHistoryEnabled,
   systemPromptRootMessage,
 } from "./root-prompt.js";
+export {
+  buildMcpToolDefinitions,
+  isSlimToolsEnabled,
+  slimOpenAIToolsForCursor,
+} from "./tool-schema.js";
 import type {
   CursorRequestPayload,
   OpenAIToolDef,
@@ -116,18 +120,6 @@ export function normalizeToolResultForTransport(
     isError: result.isError === true,
     ...(images.length > 0 && { images }),
   };
-}
-
-/**
- * Whether to truncate verbose tool descriptions/parameter docs before sending
- * them to Cursor. Default ON — full Pi/MCP prose often costs tens of thousands
- * of tokens per turn without improving tool selection. Set
- * PI_CURSOR_SLIM_TOOLS=0 to keep original schemas verbatim.
- */
-export function isSlimToolsEnabled(envValue = process.env.PI_CURSOR_SLIM_TOOLS): boolean {
-  const raw = envValue?.trim().toLowerCase();
-  if (!raw) return true;
-  return raw !== "0" && raw !== "false" && raw !== "off" && raw !== "no";
 }
 
 /**
@@ -207,107 +199,6 @@ export function isTrivialConversationalTurn(text: string): boolean {
 export function isIdentityConversationalTurn(text: string): boolean {
   const normalized = normalizeConversationalTurn(text);
   return normalized.length <= 40 && IDENTITY_CONVERSATIONAL_TURNS.has(normalized);
-}
-
-const SCHEMA_ANNOTATION_KEYS = new Set([
-  "description",
-  "title",
-  "examples",
-  "default",
-  "$comment",
-  "$schema",
-  "$id",
-  "deprecated",
-  "readOnly",
-  "writeOnly",
-]);
-
-/**
- * Remove prose-only JSON Schema annotations while preserving the executable
- * contract: property names, types, required fields, unions, enums and numeric /
- * string constraints. Parameter descriptions are the dominant MCP token cost;
- * the function-level description still tells the model when to choose a tool.
- */
-function slimJsonSchema(value: unknown, depth = 0): unknown {
-  if (value == null || depth > 12) return value;
-  if (Array.isArray(value)) return value.map((item) => slimJsonSchema(item, depth + 1));
-  if (typeof value !== "object") return value;
-
-  const input = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(input)) {
-    if (SCHEMA_ANNOTATION_KEYS.has(key) || child === undefined) continue;
-    if (key === "additionalProperties" && child === true) continue;
-    if (key === "required" && Array.isArray(child) && child.length === 0) continue;
-    out[key] = slimJsonSchema(child, depth + 1);
-  }
-  return out;
-}
-
-function conciseToolDescription(description: string): string {
-  const normalized = description.replace(/\s+/g, " ").trim();
-  if (normalized.length <= 120) return normalized;
-  const firstSentence = normalized.match(/^.{24,117}?[.!?](?:\s|$)/)?.[0]?.trim();
-  return firstSentence || `${normalized.slice(0, 117)}...`;
-}
-
-/** Compact tool prose/schemas for the Cursor MCP tool surface. */
-export function slimOpenAIToolsForCursor(tools: OpenAIToolDef[]): OpenAIToolDef[] {
-  if (!isSlimToolsEnabled()) return tools;
-  return tools.map((tool) => {
-    const fn = tool.function;
-    const parameters =
-      fn.parameters && typeof fn.parameters === "object"
-        ? (slimJsonSchema(fn.parameters) as Record<string, unknown>)
-        : fn.parameters;
-    return {
-      ...tool,
-      function: {
-        ...fn,
-        description: conciseToolDescription(fn.description || ""),
-        ...(parameters ? { parameters } : {}),
-      },
-    };
-  });
-}
-
-// Pi typically hands the provider the same `tools` array reference turn after turn within a
-// session. Slimming (recursive schema walk + description regex) and protobuf-encoding every
-// tool's schema is pure work over that array, so cache the result by array identity to skip it
-// when the tool set has not changed since the last call. Keyed on isSlimToolsEnabled() too since
-// that env-driven toggle can change between calls (e.g. tests, debug tooling).
-const mcpToolDefinitionsCache = new WeakMap<OpenAIToolDef[], Map<boolean, McpToolDefinition[]>>();
-
-export function buildMcpToolDefinitions(tools: OpenAIToolDef[]): McpToolDefinition[] {
-  const slimEnabled = isSlimToolsEnabled();
-  const byMode = mcpToolDefinitionsCache.get(tools);
-  const cached = byMode?.get(slimEnabled);
-  if (cached) return cached;
-  const prepared = slimOpenAIToolsForCursor(tools);
-  const result = prepared.map((t) => {
-    const fn = t.function;
-    const jsonSchema: JsonValue =
-      fn.parameters && typeof fn.parameters === "object"
-        ? (fn.parameters as JsonValue)
-        : { type: "object", properties: {}, required: [] };
-    // Cursor CLI's current schema uses google.protobuf.Value for
-    // McpToolDefinition.input_schema. The committed generated schema still
-    // exposes that field as bytes, but the outer wire encoding is identical
-    // for bytes and message fields (length-delimited field #3), so place the
-    // serialized Value bytes here.
-    const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, jsonSchema));
-    return create(McpToolDefinitionSchema, {
-      name: fn.name,
-      description: fn.description || "",
-      providerIdentifier: "pi",
-      toolName: fn.name,
-      inputSchema,
-    });
-  });
-  const modes = byMode ?? new Map<boolean, McpToolDefinition[]>();
-  modes.set(slimEnabled, result);
-  mcpToolDefinitionsCache.set(tools, modes);
-  return result;
 }
 
 export function summarizeRequestSize(input: {

--- a/src/stream/tool-schema.ts
+++ b/src/stream/tool-schema.ts
@@ -1,0 +1,185 @@
+/**
+ * Cursor MCP tool-schema encoding.
+ *
+ * Pi tools use JSON Schema, while Cursor carries each schema as a protobuf
+ * Value. The optional slimming pass removes model-facing prose without changing
+ * property names or the executable schema contract.
+ */
+import { create, fromJson, toBinary, type JsonValue } from "@bufbuild/protobuf";
+import { ValueSchema } from "@bufbuild/protobuf/wkt";
+
+import { McpToolDefinitionSchema, type McpToolDefinition } from "../proto/agent_pb.js";
+import type { OpenAIToolDef } from "./types.js";
+
+/**
+ * Whether to truncate verbose tool descriptions/parameter docs before sending
+ * them to Cursor. Default ON — full Pi/MCP prose often costs tens of thousands
+ * of tokens per turn without improving tool selection. Set
+ * PI_CURSOR_SLIM_TOOLS=0 to keep the original tool definitions.
+ */
+export function isSlimToolsEnabled(envValue = process.env.PI_CURSOR_SLIM_TOOLS): boolean {
+  const raw = envValue?.trim().toLowerCase();
+  if (!raw) return true;
+  return raw !== "0" && raw !== "false" && raw !== "off" && raw !== "no";
+}
+
+const SCHEMA_ANNOTATION_KEYS = new Set([
+  "description",
+  "title",
+  "examples",
+  "default",
+  "$comment",
+  "$schema",
+  "$id",
+  "deprecated",
+  "readOnly",
+  "writeOnly",
+]);
+
+/** Keywords whose values are maps from user-defined names to child schemas. */
+const NAMED_SCHEMA_MAP_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  // Draft-07 dependencies values may be either child schemas or string arrays.
+  "dependencies",
+]);
+
+/** Keywords whose value is one child schema or an array of child schemas. */
+const CHILD_SCHEMA_KEYS = new Set([
+  "additionalProperties",
+  "unevaluatedProperties",
+  "propertyNames",
+  "contains",
+  "items",
+  "additionalItems",
+  "unevaluatedItems",
+  "if",
+  "then",
+  "else",
+  "not",
+  "contentSchema",
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "prefixItems",
+]);
+
+function slimChildSchema(value: unknown, depth: number): unknown {
+  if (Array.isArray(value)) return value.map((item) => slimJsonSchema(item, depth));
+  return slimJsonSchema(value, depth);
+}
+
+/**
+ * Slim a map such as `properties` without interpreting its user-defined keys as
+ * JSON Schema keywords. A parameter may legally be named `description`,
+ * `default`, or any other annotation keyword.
+ */
+function slimNamedSchemaMap(value: unknown, depth: number): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([name, childSchema]) => [
+      name,
+      slimChildSchema(childSchema, depth),
+    ]),
+  );
+}
+
+/**
+ * Remove prose-only annotations from actual JSON Schema nodes while preserving
+ * the executable contract. Traversal is keyword-aware: blindly recursing into
+ * `properties` treats a parameter named `description` as an annotation and
+ * leaves an invalid dangling entry in `required`.
+ */
+function slimJsonSchema(value: unknown, depth = 0): unknown {
+  if (value == null || depth > 12 || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => slimJsonSchema(item, depth + 1));
+
+  const input = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(input)) {
+    if (SCHEMA_ANNOTATION_KEYS.has(key) || child === undefined) continue;
+    if (key === "additionalProperties" && child === true) continue;
+    if (key === "required" && Array.isArray(child) && child.length === 0) continue;
+    if (NAMED_SCHEMA_MAP_KEYS.has(key)) {
+      out[key] = slimNamedSchemaMap(child, depth + 1);
+      continue;
+    }
+    if (CHILD_SCHEMA_KEYS.has(key)) {
+      out[key] = slimChildSchema(child, depth + 1);
+      continue;
+    }
+    // Constraints and literal values (for example enum/const) are executable
+    // data, not schema containers. Keep them byte-for-byte equivalent.
+    out[key] = child;
+  }
+  return out;
+}
+
+function conciseToolDescription(description: string): string {
+  const normalized = description.replace(/\s+/g, " ").trim();
+  if (normalized.length <= 120) return normalized;
+  const firstSentence = normalized.match(/^.{24,117}?[.!?](?:\s|$)/)?.[0]?.trim();
+  return firstSentence || `${normalized.slice(0, 117)}...`;
+}
+
+/** Compact tool prose/schemas for the Cursor MCP tool surface. */
+export function slimOpenAIToolsForCursor(tools: OpenAIToolDef[]): OpenAIToolDef[] {
+  if (!isSlimToolsEnabled()) return tools;
+  return tools.map((tool) => {
+    const fn = tool.function;
+    const parameters =
+      fn.parameters && typeof fn.parameters === "object"
+        ? (slimJsonSchema(fn.parameters) as Record<string, unknown>)
+        : fn.parameters;
+    return {
+      ...tool,
+      function: {
+        ...fn,
+        description: conciseToolDescription(fn.description || ""),
+        ...(parameters ? { parameters } : {}),
+      },
+    };
+  });
+}
+
+// Pi typically hands the provider the same `tools` array reference turn after
+// turn. Cache the pure schema preparation + protobuf encoding by that identity
+// and the env-controlled slimming mode.
+const mcpToolDefinitionsCache = new WeakMap<OpenAIToolDef[], Map<boolean, McpToolDefinition[]>>();
+
+export function buildMcpToolDefinitions(tools: OpenAIToolDef[]): McpToolDefinition[] {
+  const slimEnabled = isSlimToolsEnabled();
+  const byMode = mcpToolDefinitionsCache.get(tools);
+  const cached = byMode?.get(slimEnabled);
+  if (cached) return cached;
+
+  const prepared = slimOpenAIToolsForCursor(tools);
+  const result = prepared.map((tool) => {
+    const fn = tool.function;
+    const jsonSchema: JsonValue =
+      fn.parameters && typeof fn.parameters === "object"
+        ? (fn.parameters as JsonValue)
+        : { type: "object", properties: {}, required: [] };
+    // Cursor CLI's current schema uses google.protobuf.Value for
+    // McpToolDefinition.input_schema. The committed generated schema still
+    // exposes that field as bytes, but the outer wire encoding is identical
+    // for bytes and message fields (length-delimited field #3), so place the
+    // serialized Value bytes here.
+    const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, jsonSchema));
+    return create(McpToolDefinitionSchema, {
+      name: fn.name,
+      description: fn.description || "",
+      providerIdentifier: "pi",
+      toolName: fn.name,
+      inputSchema,
+    });
+  });
+
+  const modes = byMode ?? new Map<boolean, McpToolDefinition[]>();
+  modes.set(slimEnabled, result);
+  mcpToolDefinitionsCache.set(tools, modes);
+  return result;
+}

--- a/tests/tool-schema.test.ts
+++ b/tests/tool-schema.test.ts
@@ -1,0 +1,110 @@
+import { fromBinary, toJson } from "@bufbuild/protobuf";
+import { ValueSchema } from "@bufbuild/protobuf/wkt";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildMcpToolDefinitions } from "../src/stream/tool-schema.js";
+import type { OpenAIToolDef } from "../src/stream/types.js";
+
+const previousSlimTools = process.env.PI_CURSOR_SLIM_TOOLS;
+
+afterEach(() => {
+  if (previousSlimTools === undefined) delete process.env.PI_CURSOR_SLIM_TOOLS;
+  else process.env.PI_CURSOR_SLIM_TOOLS = previousSlimTools;
+});
+
+function decodeSchema(tool: ReturnType<typeof buildMcpToolDefinitions>[number]): any {
+  return toJson(ValueSchema, fromBinary(ValueSchema, tool.inputSchema));
+}
+
+function descriptionPropertyTool(): OpenAIToolDef[] {
+  return [
+    {
+      type: "function",
+      function: {
+        name: "delegate",
+        description: "Delegate a task.",
+        parameters: {
+          type: "object",
+          properties: {
+            prompt: { type: "string", description: "Task prompt." },
+            description: { type: "string", description: "Short task label." },
+            options: {
+              type: "object",
+              properties: {
+                description: { type: "string", description: "Option label." },
+                value: { type: "string", description: "Option value." },
+              },
+              required: ["description", "value"],
+            },
+            entries: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  description: { type: "string", description: "Entry label." },
+                  value: { type: "string", description: "Entry value." },
+                },
+                required: ["description", "value"],
+              },
+            },
+          },
+          required: ["prompt", "description", "options", "entries"],
+        },
+      },
+    },
+  ];
+}
+
+describe("Cursor tool schema encoding", () => {
+  it.each(["0", "1"])("preserves properties named description with slim mode %s", (slimMode) => {
+    process.env.PI_CURSOR_SLIM_TOOLS = slimMode;
+    const [tool] = buildMcpToolDefinitions(descriptionPropertyTool());
+    const schema = decodeSchema(tool!);
+
+    expect(schema.properties.description).toEqual(
+      slimMode === "1" ? { type: "string" } : { type: "string", description: "Short task label." },
+    );
+    expect(schema.properties.options.properties.description).toBeDefined();
+    expect(schema.properties.entries.items.properties.description).toBeDefined();
+    expect(schema.required).toContain("description");
+    expect(schema.properties.options.required).toContain("description");
+    expect(schema.properties.entries.items.required).toContain("description");
+  });
+
+  it("distinguishes schema annotations from user-defined and literal keys", () => {
+    process.env.PI_CURSOR_SLIM_TOOLS = "1";
+    const [tool] = buildMcpToolDefinitions([
+      {
+        type: "function",
+        function: {
+          name: "schema_keywords",
+          description: "Check schema keyword contexts.",
+          parameters: {
+            type: "object",
+            properties: {
+              title: { type: "string", title: "Parameter prose" },
+              default: { type: "string", default: "fallback" },
+              literal: {
+                type: "object",
+                enum: [{ description: "literal description", title: "literal title" }],
+              },
+            },
+            required: ["title", "default", "literal"],
+            $defs: {
+              description: { type: "string", description: "Definition prose" },
+            },
+          },
+        },
+      },
+    ]);
+    const schema = decodeSchema(tool!);
+
+    expect(schema.properties.title).toEqual({ type: "string" });
+    expect(schema.properties.default).toEqual({ type: "string" });
+    expect(schema.$defs.description).toEqual({ type: "string" });
+    expect(schema.properties.literal.enum).toEqual([
+      { description: "literal description", title: "literal title" },
+    ]);
+    expect(schema.required).toEqual(["title", "default", "literal"]);
+  });
+});


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                            
                                                                                                                                                                                                                         
   Fix tool schema slimming so user-defined property names such as `description`, `title`, and `default` are not mistaken for JSON Schema annotations and removed.                                                       
                                                                                                                                                                                                                         
   This was exposed by Gemini 3.6/3.7, which rejects the resulting invalid schema with a provider HTTP 400 surfaced by Cursor as `resource_exhausted`.                                                                   
                                                                                                                                                                                                                         
   ## Problem                                                                                                                                                                                                            
                                                                                                                                                                                                                         
   The previous `slimJsonSchema()` recursively removed every key matching a schema annotation:                                                                                                                           
                                                                                                                                                                                                                         
   ```json                                                                                                                                                                                                               
   {                                                                                                                                                                                                                     
     "type": "object",                                                                                                                                                                                                   
     "properties": {                                                                                                                                                                                                     
       "prompt": { "type": "string" },                                                                                                                                                                                   
       "description": { "type": "string" }                                                                                                                                                                               
     },                                                                                                                                                                                                                  
     "required": ["prompt", "description"]                                                                                                                                                                               
   }                                                                                                                                                                                                                     
 ```                                                                                                                                                                                                                     
                                                                                                                                                                                                                         
 When traversing the properties map, it treated the user-defined description property as an annotation and produced:                                                                                                     
                                                                                                                                                                                                                         
 ```json                                                                                                                                                                                                                 
   {                                                                                                                                                                                                                     
     "type": "object",                                                                                                                                                                                                   
     "properties": {                                                                                                                                                                                                     
       "prompt": { "type": "string" }                                                                                                                                                                                    
     },                                                                                                                                                                                                                  
     "required": ["prompt", "description"]                                                                                                                                                                               
   }                                                                                                                                                                                                                     
 ```                                                                                                                                                                                                                     
                                                                                                                                                                                                                         
 This leaves a dangling required entry and changes the tool contract.                                                                                                                                                    
                                                                                                                                                                                                                         
 The issue is not specific to Gemini or a particular tool. Any property whose name matches an annotation keyword could be removed.                                                                                       
                                                                                                                                                                                                                         
 Fix                                                                                                                                                                                                                     
                                                                                                                                                                                                                         
 - Extract tool schema preparation and MCP protobuf encoding into src/stream/tool-schema.ts.                                                                                                                             
 - Make schema traversal keyword-aware:                                                                                                                                                                                  
     - Remove annotations only from actual schema nodes.                                                                                                                                                                 
     - Preserve user-defined keys inside named schema maps such as:                                                                                                                                                      
         - properties                                                                                                                                                                                                    
         - patternProperties                                                                                                                                                                                             
         - $defs                                                                                                                                                                                                         
         - definitions                                                                                                                                                                                                   
         - dependentSchemas                                                                                                                                                                                              
         - dependencies                                                                                                                                                                                                  
     - Continue recursively slimming child schemas.                                                                                                                                                                      
     - Preserve literal values inside enum and const.                                                                                                                                                                    
 - Keep the existing request-build.ts exports as a compatibility façade.                                                                                                                                                 
 - Make native-core.ts depend directly on the new tool schema owner.                                                                                                                                                     
                                                                                                                                                                                                                         
 There are no Gemini model checks, tool-name checks, or third-party extension checks.                                                                                                                                    
                                                                                                                                                                                                                         
 Tests                                                                                                                                                                                                                   
                                                                                                                                                                                                                         
 Added regression coverage that decodes the final McpToolDefinition.inputSchema and verifies:                                                                                                                            
                                                                                                                                                                                                                         
 - Slimming enabled and disabled                                                                                                                                                                                         
 - Root-level properties named description                                                                                                                                                                               
 - Nested object properties                                                                                                                                                                                              
 - Object schemas inside array items                                                                                                                                                                                     
 - $defs entries                                                                                                                                                                                                         
 - Properties named title and default                                                                                                                                                                                    
 - Literal objects containing annotation-like keys                                                                                                                                                                       
                                                                                                                                                                                                                         
 Manual verification was also performed with Gemini 3.7 Flash and the real Agent tool while PI_CURSOR_SLIM_TOOLS=1.                                                                                                      
                                                                                                                                                                                                                         
 Validation                                                                                                                                                                                                              
                                                                                                                                                                                                                         
 ```text                                                                                                                                                                                                                 
   npm run check                                                                                                                                                                                                         
 ```                                                                                                                                                                                                                     
                                                                                                                                                                                                                         
 - 28 test files passed                                                                                                                                                                                                  
 - 224 tests passed                                                                                                                                                                                                      
 - Typecheck, lint, formatting, security check, proto check, Vitest, and legacy tests all passed                                                                                                                         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved MCP tool compatibility by encoding tool definitions more consistently.
  - Reduced unnecessary schema metadata sent with tools for more efficient requests.
  - Preserved user-defined parameter names and meaningful schema details, including required fields and nested definitions.
  - Tool descriptions are now condensed to concise first sentences for clearer presentation.
  - Added configurable control over schema slimming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->