### PR TITLE
fix: cap GPT-5.6 Luna context at the 500k OpenAI prompt limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Cursor GPT-5.6 Luna/Sol/Terra no longer advertise a 1M window that OpenAI rejects at 500k.** Live `GetUsableModels` labels the 272k default "GPT-5.6 Luna 1M High", so Pi inferred `contextWindow: 1000000` and skipped auto-compaction until ~983k. OpenAI (via Cursor) then 400'd: `This model's maximum prompt length is 500000 but the request contains 503167 tokens.` Display-name "1M" is ignored unless the id has `-1m`; 1m variants are capped at 500k so threshold compaction fires first. Claude 1M rows are unchanged.
+
 ## [1.4.29] - 2026-08-30
 
 ### Changed

--- a/src/models/limits.ts
+++ b/src/models/limits.ts
@@ -9,8 +9,40 @@
 export const DEFAULT_CONTEXT_WINDOW = 200_000;
 export const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 
+/** GPT-5.6 default (272k short-context tier). */
+export const GPT56_DEFAULT_CONTEXT_WINDOW = 272_000;
+
+/**
+ * OpenAI-via-Cursor GPT-5.6 (Luna / Sol / Terra) rejects prompts above this,
+ * even when Cursor labels the row "1M" or advertises `context=1m`.
+ * Observed: `maximum prompt length is 500000 but the request contains 503167`.
+ */
+export const GPT56_MAX_PROMPT_TOKENS = 500_000;
+
+export function isGpt56Model(id: string, name = ""): boolean {
+  return /gpt-5\.6/.test(`${id} ${name}`.toLowerCase());
+}
+
+/** Cap GPT-5.6 windows at the real OpenAI prompt limit; leave other families alone. */
+export function clampCursorContextWindow(id: string, name: string, window: number): number {
+  if (isGpt56Model(id, name) && window > GPT56_MAX_PROMPT_TOKENS) {
+    return GPT56_MAX_PROMPT_TOKENS;
+  }
+  return window;
+}
+
 export function inferCursorContextWindow(id: string, name: string): number {
-  const text = `${id} ${name}`.toLowerCase();
+  const idLower = id.toLowerCase();
+  const text = `${idLower} ${name}`.toLowerCase();
+
+  // GPT-5.6 usable-model display names include "1M" even for the 272k default
+  // (id `gpt-5.6-luna-high`, name "GPT-5.6 Luna 1M High"). Trust the id's `-1m`
+  // marker, not the name, and never advertise more than the 500k prompt cap.
+  if (isGpt56Model(id, name)) {
+    if (/(?:^|-)1m(?:-|$)/.test(idLower)) return GPT56_MAX_PROMPT_TOKENS;
+    return GPT56_DEFAULT_CONTEXT_WINDOW;
+  }
+
   if (/\b1\s*m\b|(?:^|-)1m(?:-|$)/.test(text)) return 1_000_000;
   if (/\b272\s*k\b|(?:^|-)272k(?:-|$)/.test(text)) return 272_000;
   return DEFAULT_CONTEXT_WINDOW;

--- a/src/models/parameterized.ts
+++ b/src/models/parameterized.ts
@@ -9,7 +9,11 @@ import type {
   CursorParameterizedVariant,
 } from "../client/cursor-wire.js";
 import type { CursorModel } from "../stream/model-discovery.js";
-import { inferCursorContextWindow, inferCursorMaxOutputTokens } from "./limits.js";
+import {
+  clampCursorContextWindow,
+  inferCursorContextWindow,
+  inferCursorMaxOutputTokens,
+} from "./limits.js";
 import { supportsReasoningModelId } from "./processing.js";
 
 export const GPT55_VARIANTS = [
@@ -245,11 +249,15 @@ export function buildParameterizedRowsFromGroup(options: {
     options.requestedMaxMode,
     hasEffortParameter,
   );
-  const contextWindow = contextWindowFromParameter(
-    context,
-    options.requestedMaxMode
-      ? (options.model.contextTokenLimitForMaxMode ?? options.model.contextTokenLimit ?? 200_000)
-      : (options.model.contextTokenLimit ?? 200_000),
+  const contextWindow = clampCursorContextWindow(
+    options.model.name,
+    options.model.clientDisplayName || options.model.name,
+    contextWindowFromParameter(
+      context,
+      options.requestedMaxMode
+        ? (options.model.contextTokenLimitForMaxMode ?? options.model.contextTokenLimit ?? 200_000)
+        : (options.model.contextTokenLimit ?? 200_000),
+    ),
   );
 
   return options.variants.flatMap((variant) => {

--- a/src/models/processing.ts
+++ b/src/models/processing.ts
@@ -5,6 +5,7 @@
 import type { CursorModel } from "../stream/model-discovery.js";
 import type { CursorNativeModelRouting } from "../stream/model-routing.js";
 import { estimateModelCost } from "./cost.js";
+import { clampCursorContextWindow } from "./limits.js";
 import { ProviderConstant, type PiThinkingLevel } from "../types/enums.js";
 
 export type CursorModelRouting = CursorNativeModelRouting;
@@ -270,6 +271,7 @@ export function processModels(raw: CursorModel[]): ProcessedModel[] {
       result.push({
         ...rep,
         id,
+        contextWindow: clampCursorContextWindow(id, rep.name, rep.contextWindow),
         supportsEffort: true,
         effortMap,
         rawModelByEffort,
@@ -278,7 +280,11 @@ export function processModels(raw: CursorModel[]): ProcessedModel[] {
     } else {
       // Keep single entries as-is (base model without effort variants)
       for (const model of g.efforts.values()) {
-        result.push({ ...model, supportsEffort: false });
+        result.push({
+          ...model,
+          contextWindow: clampCursorContextWindow(model.id, model.name, model.contextWindow),
+          supportsEffort: false,
+        });
       }
     }
   }

--- a/tests/model-limits.test.ts
+++ b/tests/model-limits.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import {
   DEFAULT_MAX_OUTPUT_TOKENS,
+  GPT56_DEFAULT_CONTEXT_WINDOW,
+  GPT56_MAX_PROMPT_TOKENS,
+  clampCursorContextWindow,
   inferCursorContextWindow,
   inferCursorMaxOutputTokens,
 } from "../src/models/limits.js";
-import { FALLBACK_MODELS } from "../src/models/parameterized.js";
+import { FALLBACK_MODELS, modelsFromParameterizedMetadata } from "../src/models/parameterized.js";
+import { processModels } from "../src/models/processing.js";
+import type { CursorParameterizedModel } from "../src/client/cursor-wire.js";
 
 describe("inferCursorContextWindow", () => {
   it("reads the 1M marker from either the id or the display name", () => {
@@ -16,6 +21,46 @@ describe("inferCursorContextWindow", () => {
   it("reads the 272K marker and otherwise falls back to 200K", () => {
     expect(inferCursorContextWindow("gpt-5.5-high", "GPT-5.5 272K High")).toBe(272_000);
     expect(inferCursorContextWindow("composer-2", "Composer 2")).toBe(200_000);
+  });
+
+  it("does not treat GPT-5.6 display-name 1M as a 1M window", () => {
+    // Cursor's GetUsableModels labels the 272k default "GPT-5.6 Luna 1M High".
+    expect(inferCursorContextWindow("gpt-5.6-luna-high", "GPT-5.6 Luna 1M High")).toBe(
+      GPT56_DEFAULT_CONTEXT_WINDOW,
+    );
+    expect(inferCursorContextWindow("gpt-5.6-luna-medium", "GPT-5.6 Luna 1M")).toBe(
+      GPT56_DEFAULT_CONTEXT_WINDOW,
+    );
+    expect(inferCursorContextWindow("gpt-5.6-sol-high", "GPT-5.6 Sol 1M High")).toBe(
+      GPT56_DEFAULT_CONTEXT_WINDOW,
+    );
+    expect(inferCursorContextWindow("gpt-5.6-luna-high-fast", "GPT-5.6 Luna High Fast")).toBe(
+      GPT56_DEFAULT_CONTEXT_WINDOW,
+    );
+  });
+
+  it("caps GPT-5.6 -1m ids at the 500k OpenAI prompt limit", () => {
+    expect(inferCursorContextWindow("gpt-5.6-luna-1m-high", "GPT-5.6 Luna 1M High")).toBe(
+      GPT56_MAX_PROMPT_TOKENS,
+    );
+    expect(inferCursorContextWindow("gpt-5.6-terra-1m-medium", "GPT-5.6 Terra 1M")).toBe(
+      GPT56_MAX_PROMPT_TOKENS,
+    );
+  });
+});
+
+describe("clampCursorContextWindow", () => {
+  it("caps GPT-5.6 1M parameterized windows at 500k and leaves Claude 1M alone", () => {
+    expect(clampCursorContextWindow("gpt-5.6-luna", "GPT-5.6 Luna", 1_000_000)).toBe(
+      GPT56_MAX_PROMPT_TOKENS,
+    );
+    expect(clampCursorContextWindow("gpt-5.6-luna-1m", "GPT-5.6 Luna 1M", 1_000_000)).toBe(
+      GPT56_MAX_PROMPT_TOKENS,
+    );
+    expect(clampCursorContextWindow("claude-4.6-opus-high", "Opus 4.6 1M", 1_000_000)).toBe(
+      1_000_000,
+    );
+    expect(clampCursorContextWindow("gpt-5.6-luna-high", "GPT-5.6 Luna", 272_000)).toBe(272_000);
   });
 });
 
@@ -62,5 +107,64 @@ describe("bundled fallback catalog", () => {
     const oneMillion = FALLBACK_MODELS.filter((m) => /\b1M\b/.test(m.name));
     expect(oneMillion.length).toBeGreaterThan(0);
     for (const model of oneMillion) expect(model.contextWindow).toBe(1_000_000);
+  });
+});
+
+describe("GPT-5.6 Luna parameterized catalog", () => {
+  const luna: CursorParameterizedModel = {
+    name: "gpt-5.6-luna",
+    clientDisplayName: "GPT-5.6 Luna",
+    supportsMaxMode: true,
+    contextTokenLimit: 272_000,
+    contextTokenLimitForMaxMode: 1_000_000,
+    variants: [
+      {
+        isMaxMode: false,
+        parameters: [
+          { id: "context", value: "272k" },
+          { id: "reasoning", value: "high" },
+          { id: "fast", value: "false" },
+        ],
+      },
+      {
+        isMaxMode: true,
+        parameters: [
+          { id: "context", value: "1m" },
+          { id: "reasoning", value: "high" },
+          { id: "fast", value: "false" },
+        ],
+      },
+    ],
+  };
+
+  it("registers the 272k default and caps the 1m variant at 500k", () => {
+    const rows = modelsFromParameterizedMetadata([luna]);
+    const defaultHigh = rows.find((m) => m.id === "gpt-5.6-luna-high");
+    const oneMHigh = rows.find((m) => m.id === "gpt-5.6-luna-1m-high");
+    expect(defaultHigh?.contextWindow).toBe(GPT56_DEFAULT_CONTEXT_WINDOW);
+    expect(oneMHigh?.contextWindow).toBe(GPT56_MAX_PROMPT_TOKENS);
+  });
+
+  it("grouped Pi model ids inherit the 500k cap so auto-compaction fires in time", () => {
+    const processed = processModels(modelsFromParameterizedMetadata([luna]));
+    const grouped1m = processed.find((m) => m.id === "gpt-5.6-luna-1m");
+    const groupedDefault = processed.find((m) => m.id === "gpt-5.6-luna");
+    expect(groupedDefault?.contextWindow).toBe(GPT56_DEFAULT_CONTEXT_WINDOW);
+    expect(grouped1m?.contextWindow).toBe(GPT56_MAX_PROMPT_TOKENS);
+  });
+
+  it("caps a cached 1M raw Luna row even when parameterized discovery is empty", () => {
+    const processed = processModels([
+      {
+        id: "gpt-5.6-luna-high",
+        name: "GPT-5.6 Luna 1M High",
+        reasoning: true,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+    ]);
+    expect(processed).toHaveLength(1);
+    expect(processed[0]?.id).toBe("gpt-5.6-luna");
+    expect(processed[0]?.contextWindow).toBe(GPT56_MAX_PROMPT_TOKENS);
   });
 });


### PR DESCRIPTION
## Summary

Cursor's live `GetUsableModels` labels GPT-5.6 Luna/Sol/Terra as "1M" even for the 272k default (`gpt-5.6-luna-high` → "GPT-5.6 Luna 1M High"). Pi inferred `contextWindow: 1000000` and skipped auto-compaction until ~983k.

OpenAI (via Cursor) then 400'd:

```
This model's maximum prompt length is 500000 but the request contains 503167 tokens.
```

## Fix

- Ignore display-name "1M" for GPT-5.6 unless the id has `-1m`
- Default GPT-5.6 windows to 272k
- Cap `-1m` / parameterized `context=1m` variants at **500k** (the real prompt limit) so threshold compaction fires first
- Claude 1M rows are unchanged

## Test plan

- [x] `bun test tests/model-limits.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected GPT-5.6 model context limits to match supported capacity.
  - GPT-5.6 1M variants are now capped at 500k tokens, preventing requests from exceeding OpenAI’s limit.
  - Automatic compaction now occurs before the supported limit is reached, avoiding related request failures.
  - Claude models with 1M context windows remain unchanged.

- **Documentation**
  - Added an unreleased changelog entry describing the corrected context-window behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->