### PR TITLE
fix: copy Cursor contextTokenLimit onto cursor-prefixed GetUsableModels rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **GetUsableModels `cursor-*` rows no longer keep a guessed 200K window when Cursor already published `contextTokenLimit`.** Parameterized discovery lists `grok-4.6` at 256K, but Pi also registers `cursor-grok-4.6` from GetUsableModels with `inferCursorContextWindow` (default 200K). Different ids meant both survived catalog merge, so compaction used the 200K alias. The parameterized window is now copied onto the `cursor-` prefixed twin. `inferCursorContextWindow` also treats Grok 4.5/4.6 as 256K when metadata is missing.
+
 ## [1.4.29] - 2026-08-30
 
 ### Changed

--- a/src/models/limits.ts
+++ b/src/models/limits.ts
@@ -1,9 +1,12 @@
 /**
  * Context-window and output-token ceilings for Cursor models.
  *
- * Cursor's `ModelDetails` carries neither number, so both are inferred from the
- * model id and display name. Kept in a dependency-free module because the model
- * catalog needs it at startup and must not drag the transport stack in with it.
+ * GetUsableModels `ModelDetails` carries neither number, so both are inferred
+ * from the model id and display name. AvailableModels parameterized metadata
+ * *does* send `contextTokenLimit`; prefer that at catalog-merge time and treat
+ * this helper as the GetUsableModels-only fallback. Kept in a dependency-free
+ * module because the model catalog needs it at startup and must not drag the
+ * transport stack in with it.
  */
 
 export const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -13,6 +16,11 @@ export function inferCursorContextWindow(id: string, name: string): number {
   const text = `${id} ${name}`.toLowerCase();
   if (/\b1\s*m\b|(?:^|-)1m(?:-|$)/.test(text)) return 1_000_000;
   if (/\b272\s*k\b|(?:^|-)272k(?:-|$)/.test(text)) return 272_000;
+  if (/\b256\s*k\b|(?:^|-)256k(?:-|$)/.test(text)) return 256_000;
+  // Cursor Grok 4.5 / 4.6 advertise 256K via contextTokenLimit; the display
+  // name has no "256K" suffix, so GetUsableModels rows would otherwise stay at
+  // the 200K default. Do not match Grok 4.20 (`grok-4-20`).
+  if (/grok[- ]4\.[56](?:\b|-)/.test(text)) return 256_000;
   return DEFAULT_CONTEXT_WINDOW;
 }
 

--- a/src/models/parameterized.ts
+++ b/src/models/parameterized.ts
@@ -392,6 +392,7 @@ export function augmentCursorModels(
   const metadataRows =
     modelsFromParameterizedMetadata(parameterizedModels).map(normalizeDisplayModel);
   for (const model of metadataRows) byId.set(model.id, model);
+  overlayParameterizedContextWindows(byId, metadataRows);
 
   // Fallback for static/offline discovery. Cursor exposes GPT-5.5 context as
   // parameters (272K vs 1M), not distinct backend model IDs.
@@ -400,6 +401,25 @@ export function augmentCursorModels(
   }
 
   return [...byId.values()];
+}
+
+/**
+ * GetUsableModels ids are `cursor-<serverModel>-<effort>`. Parameterized
+ * AvailableModels rows use `<serverModel>-<effort>` and carry Cursor's real
+ * `contextTokenLimit`. Different ids meant both survived catalog merge, so Pi
+ * kept a 200K inferred twin (`cursor-grok-4.6`) next to the 256K metadata row
+ * (`grok-4.6`) and compaction used the guessed window.
+ */
+function overlayParameterizedContextWindows(
+  byId: Map<string, CursorModel>,
+  metadataRows: CursorModel[],
+): void {
+  for (const row of metadataRows) {
+    if (row.id.startsWith("cursor-")) continue;
+    const existing = byId.get(`cursor-${row.id}`);
+    if (!existing || existing.contextWindow === row.contextWindow) continue;
+    byId.set(`cursor-${row.id}`, { ...existing, contextWindow: row.contextWindow });
+  }
 }
 
 // The bundled catalog is a snapshot of a live discovery response, so its derived

--- a/tests/model-limits.test.ts
+++ b/tests/model-limits.test.ts
@@ -17,6 +17,14 @@ describe("inferCursorContextWindow", () => {
     expect(inferCursorContextWindow("gpt-5.5-high", "GPT-5.5 272K High")).toBe(272_000);
     expect(inferCursorContextWindow("composer-2", "Composer 2")).toBe(200_000);
   });
+
+  it("treats Cursor Grok 4.5/4.6 as 256K and leaves Grok 4.20 at 200K", () => {
+    expect(inferCursorContextWindow("cursor-grok-4.6-high", "Cursor Grok 4.6")).toBe(256_000);
+    expect(inferCursorContextWindow("grok-4.6", "Cursor Grok 4.6 Medium")).toBe(256_000);
+    expect(inferCursorContextWindow("cursor-grok-4.5-medium", "Cursor Grok 4.5")).toBe(256_000);
+    expect(inferCursorContextWindow("gpt-5.6-luna", "GPT-5.6 Luna 256K")).toBe(256_000);
+    expect(inferCursorContextWindow("grok-4-20", "Grok 4.20")).toBe(200_000);
+  });
 });
 
 describe("inferCursorMaxOutputTokens", () => {

--- a/tests/parameterized-context.test.ts
+++ b/tests/parameterized-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import type { CursorParameterizedModel } from "../src/client/cursor-wire.js";
+import { augmentCursorModels } from "../src/models/parameterized.js";
+import { processModels } from "../src/models/processing.js";
+import type { CursorModel } from "../src/stream/model-discovery.js";
+
+function raw(id: string, name: string, contextWindow = 200_000): CursorModel {
+  return { id, name, reasoning: false, contextWindow, maxTokens: 64_000 };
+}
+
+const grok46: CursorParameterizedModel = {
+  name: "grok-4.6",
+  clientDisplayName: "Cursor Grok 4.6",
+  supportsMaxMode: true,
+  supportsNonMaxMode: true,
+  contextTokenLimit: 256_000,
+  contextTokenLimitForMaxMode: 256_000,
+  variants: [
+    {
+      parameters: [
+        { id: "effort", value: "low" },
+        { id: "fast", value: "false" },
+      ],
+      isMaxMode: false,
+    },
+    {
+      parameters: [
+        { id: "effort", value: "medium" },
+        { id: "fast", value: "false" },
+      ],
+      isMaxMode: false,
+    },
+    {
+      parameters: [
+        { id: "effort", value: "high" },
+        { id: "fast", value: "false" },
+      ],
+      isMaxMode: false,
+    },
+  ],
+};
+
+describe("augmentCursorModels context overlay", () => {
+  it("copies parameterized contextTokenLimit onto cursor-prefixed GetUsableModels rows", () => {
+    const augmented = augmentCursorModels(
+      [
+        raw("cursor-grok-4.6-high", "Cursor Grok 4.6"),
+        raw("cursor-grok-4.6-medium", "Cursor Grok 4.6 Medium"),
+        raw("cursor-grok-4.6-low", "Cursor Grok 4.6 Low"),
+      ],
+      [grok46],
+    );
+
+    const prefixed = augmented.filter((model) => model.id.startsWith("cursor-grok-4.6"));
+    expect(prefixed).toHaveLength(3);
+    for (const model of prefixed) expect(model.contextWindow).toBe(256_000);
+
+    const collapsed = processModels(augmented).find((model) => model.id === "cursor-grok-4.6");
+    expect(collapsed?.contextWindow).toBe(256_000);
+  });
+
+  it("does not invent cursor-prefixed rows when GetUsableModels omitted them", () => {
+    const augmented = augmentCursorModels([], [grok46]);
+    expect(augmented.some((model) => model.id.startsWith("cursor-"))).toBe(false);
+    expect(augmented.some((model) => model.id.startsWith("grok-4.6"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Pi was auto-compacting `cursor-grok-4.6` every tool call. Cursor's live parameterized catalog already publishes `contextTokenLimit: 256000` for grok-4.6 (and grok-4.5). GetUsableModels rows are inferred at the 200K default because the display name has no 256K suffix.

Those two catalogs use different ids (`cursor-grok-4.6-high` vs `grok-4.6-high`), so both survived merge. `processModels` collapsed the GetUsableModels family to `cursor-grok-4.6` at 200K. Compaction threshold is 200000-16384 = 183616, which is why a 197k session looped.

## What

- Copy parameterized `contextWindow` onto the matching `cursor-` prefixed GetUsableModels twin during `augmentCursorModels`.
- Infer Grok 4.5/4.6 (not 4.20) as 256K when metadata is missing; also honor a 256K name marker.

## Test

`bun test tests/model-limits.test.ts tests/parameterized-context.test.ts` and full `bun test` (231 pass). `bun run proto:check` fails on this machine against origin/main independently of this diff (generated `agent_pb.ts` vs `proto/agent.proto`).
