### PR TITLE
fix: drop a checkpoint whose blobs were evicted at the entry bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **A checkpoint whose blobs the entry bound evicted is no longer kept and replayed with blank history.** The 512-entry blob store evicts oldest-first, but a checkpoint addresses its history by blob id and Cursor answers a request for a blob we no longer hold with an empty result rather than an error, so the conversation came back structurally intact with the evicted turns silently blank. `markBlobMiss` only caught this one turn late, after Cursor had already asked. `mergeBlobStore` now drops the checkpoint whenever its trim evicts anything — the same call `journal.checkpoint_dropped_incomplete_blobs` already makes at restore time — which also covers the merge paths that write no new checkpoint but can still evict blobs an earlier turn's checkpoint references. Costs one full-history rebuild from pi's transcript.
+
 ## [1.4.30] - 2026-09-02
 
 ### Fixed

--- a/src/stream/session-state.ts
+++ b/src/stream/session-state.ts
@@ -238,10 +238,27 @@ export function trimBlobStore(
   return { removed, totalBytes };
 }
 
+/**
+ * Clear the upstream checkpoint bytes and their metadata, leaving mid-pause metadata and the blob
+ * store untouched. A dropped checkpoint falls back to a full-history rebuild, and that rebuild
+ * reads both.
+ */
+function clearCheckpointBytesOnly(stored: StoredConversation): void {
+  stored.checkpoint = null;
+  delete stored.checkpointSource;
+  delete stored.checkpointTurnCount;
+  delete stored.checkpointHistoryFingerprint;
+}
+
+/**
+ * Merge a stream's blobs into the retained per-conversation store, trimming to the byte and entry
+ * bounds. Returns how many blobs the trim evicted, which decides whether a checkpoint may be kept:
+ * see the eviction note below.
+ */
 export function mergeBlobStore(
   stored: StoredConversation,
   blobStore: Map<string, Uint8Array>,
-): void {
+): { evicted: number } {
   // Delete-then-set moves each still-referenced blob to the end of the insertion order, which is
   // what `trimBlobStore` treats as newest. Plain `set` leaves an existing key in place, so the
   // system-prompt blob — written first on every build, and pointed at by `rootPromptMessagesJson`
@@ -263,8 +280,19 @@ export function mergeBlobStore(
       maxBytes: MAX_CONVERSATION_BLOB_BYTES,
       maxEntries: MAX_ACTIVE_BLOB_ENTRIES,
     });
+    // Cursor answers a request for an evicted blob with an empty result rather than an error, so a
+    // checkpoint that outlived its blobs replays with those turns silently blank. Drop it and take
+    // the full-history rebuild, same as `journal.checkpoint_dropped_incomplete_blobs` at restore.
+    debugLog("conversation.checkpoint_dropped_evicted_blobs", {
+      conversationId: stored.conversationId,
+      hadCheckpoint: !!stored.checkpoint,
+      evicted: trimmed.removed,
+      entries: stored.blobStore.size,
+    });
+    clearCheckpointBytesOnly(stored);
   }
   stored.lastAccessMs = Date.now();
+  return { evicted: trimmed.removed };
 }
 
 export function commitStoredCheckpoint(
@@ -276,11 +304,13 @@ export function commitStoredCheckpoint(
   convKey?: string,
 ): void {
   const completedHistory = [...completedTurns, currentTurn];
-  mergeBlobStore(stored, blobStore);
-  stored.checkpoint = checkpointBytes;
-  stored.checkpointSource = "upstream";
-  stored.checkpointTurnCount = completedHistory.length;
-  stored.checkpointHistoryFingerprint = fingerprintCompletedTurns(completedHistory);
+  const { evicted } = mergeBlobStore(stored, blobStore);
+  if (evicted === 0) {
+    stored.checkpoint = checkpointBytes;
+    stored.checkpointSource = "upstream";
+    stored.checkpointTurnCount = completedHistory.length;
+    stored.checkpointHistoryFingerprint = fingerprintCompletedTurns(completedHistory);
+  }
   clearStoredMidPauseMetadata(stored);
   stored.lastAccessMs = Date.now();
   if (convKey) persistJournal(convKey, stored);
@@ -324,11 +354,13 @@ export function persistAbortedConversationState(
   // makes the next tool-continuation / idle-retry treat a still-valid checkpoint
   // as stale. Keep the checkpoint keyed to the completed history only.
   if (latestCheckpoint) {
-    mergeBlobStore(stored, blobStore);
-    stored.checkpoint = latestCheckpoint;
-    stored.checkpointSource = "upstream";
-    stored.checkpointTurnCount = completedTurns.length;
-    stored.checkpointHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
+    const { evicted } = mergeBlobStore(stored, blobStore);
+    if (evicted === 0) {
+      stored.checkpoint = latestCheckpoint;
+      stored.checkpointSource = "upstream";
+      stored.checkpointTurnCount = completedTurns.length;
+      stored.checkpointHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
+    }
     stored.lastAccessMs = Date.now();
     persistJournal(convKey, stored);
   } else {
@@ -355,10 +387,11 @@ export function commitStoredCheckpointMidPause(
   pendingToolCalls: Array<{ toolCallId: string; toolName: string }>,
   convKey?: string,
 ): void {
-  mergeBlobStore(stored, blobStore);
+  const { evicted } = mergeBlobStore(stored, blobStore);
   const completedHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
-  if (checkpointBytes) {
-    stored.checkpoint = checkpointBytes;
+  const usableCheckpoint = evicted === 0 ? checkpointBytes : null;
+  if (usableCheckpoint) {
+    stored.checkpoint = usableCheckpoint;
     stored.checkpointSource = "upstream";
     stored.checkpointTurnCount = completedTurns.length;
     stored.checkpointHistoryFingerprint = completedHistoryFingerprint;

--- a/tests/durability.test.ts
+++ b/tests/durability.test.ts
@@ -5,12 +5,14 @@
 import { describe, expect, it } from "bun:test";
 import { parseMessages } from "../src/stream/message-parsing.js";
 import {
+  commitStoredCheckpoint,
   discardStaleCheckpointIfNeeded,
   fingerprintCompletedTurns,
   mergeBlobStore,
   trimBlobStore,
 } from "../src/stream/session-state.js";
-import type { OpenAIMessage, StoredConversation } from "../src/stream/types.js";
+import { MAX_ACTIVE_BLOB_ENTRIES } from "../src/stream/tuning.js";
+import type { OpenAIMessage, ParsedTurn, StoredConversation } from "../src/stream/types.js";
 
 const PNG_HEADER = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
@@ -165,5 +167,79 @@ describe("blob store eviction order", () => {
     expect(store.has("b0")).toBe(false);
     expect(store.has("b1")).toBe(false);
     expect(store.has("b4")).toBe(true);
+  });
+});
+
+/**
+ * Restoring from the journal already refuses to pair a checkpoint with an incomplete blob set
+ * (`journal.checkpoint_dropped_incomplete_blobs`), because Cursor answers a missing blob with an
+ * empty result and the turn comes back blank rather than failing. Committing a checkpoint has to
+ * hold the same line: the entry bound evicts oldest-first on a conversation that outgrows it, and
+ * keeping the checkpoint anyway hands Cursor references we can no longer serve.
+ */
+describe("checkpoint durability across blob eviction", () => {
+  const turn: ParsedTurn = { userText: "do the thing", steps: [] };
+
+  it("drops a checkpoint whose blobs the entry bound just evicted", () => {
+    const stored = storedConversation();
+    const blobStore = new Map<string, Uint8Array>();
+    for (let i = 0; i <= MAX_ACTIVE_BLOB_ENTRIES; i++) {
+      blobStore.set(`blob-${i}`, new Uint8Array(8).fill(i % 256));
+    }
+
+    commitStoredCheckpoint(stored, new Uint8Array([1, 2, 3, 4]), blobStore, [], turn);
+
+    expect(stored.blobStore.size).toBe(MAX_ACTIVE_BLOB_ENTRIES);
+    expect(stored.blobStore.has("blob-0")).toBe(false);
+    expect(stored.checkpoint).toBeNull();
+    expect(stored.checkpointTurnCount).toBeUndefined();
+    expect(stored.checkpointHistoryFingerprint).toBeUndefined();
+  });
+
+  it("keeps the checkpoint when the whole blob set survived", () => {
+    const stored = storedConversation();
+    const checkpoint = new Uint8Array([1, 2, 3, 4]);
+
+    commitStoredCheckpoint(stored, checkpoint, new Map([["blob-0", new Uint8Array(8)]]), [], turn);
+
+    expect(stored.checkpoint).toBe(checkpoint);
+    expect(stored.checkpointTurnCount).toBe(1);
+  });
+
+  it("drops an earlier checkpoint when a merge that writes no checkpoint evicts blobs", () => {
+    const stored = storedConversation({
+      checkpoint: new Uint8Array([9, 9, 9, 9]),
+      checkpointSource: "upstream",
+      checkpointTurnCount: 3,
+      checkpointHistoryFingerprint: "fp-3",
+    });
+    const blobStore = new Map<string, Uint8Array>();
+    for (let i = 0; i <= MAX_ACTIVE_BLOB_ENTRIES; i++) {
+      blobStore.set(`blob-${i}`, new Uint8Array(8).fill(i % 256));
+    }
+
+    const { evicted } = mergeBlobStore(stored, blobStore);
+
+    expect(evicted).toBeGreaterThan(0);
+    expect(stored.checkpoint).toBeNull();
+    expect(stored.checkpointSource).toBeUndefined();
+    expect(stored.checkpointTurnCount).toBeUndefined();
+    expect(stored.checkpointHistoryFingerprint).toBeUndefined();
+  });
+
+  it("leaves an earlier checkpoint alone when a merge evicts nothing", () => {
+    const checkpoint = new Uint8Array([9, 9, 9, 9]);
+    const stored = storedConversation({
+      checkpoint,
+      checkpointSource: "upstream",
+      checkpointTurnCount: 3,
+      checkpointHistoryFingerprint: "fp-3",
+    });
+
+    const { evicted } = mergeBlobStore(stored, new Map([["blob-0", new Uint8Array(8)]]));
+
+    expect(evicted).toBe(0);
+    expect(stored.checkpoint).toBe(checkpoint);
+    expect(stored.checkpointTurnCount).toBe(3);
   });
 });


### PR DESCRIPTION
A checkpoint addresses its history by blob id, and the 512-entry blob store evicts oldest-first on any conversation that runs a few hundred tool calls. Cursor answers a request for a blob we no longer hold with an empty result rather than an error, so the conversation comes back structurally intact with the evicted turns silently blank. That is worse than a failed turn: the agent cannot tell its own history is missing, so it re-plans and redoes work that already completed.

Recovering once Cursor asks for the missing blob is too late, because the turn that triggered the miss has already replayed with holes. Refusing to keep a checkpoint we can no longer fully serve is the same call the journal reader already makes at restore time (`journal.checkpoint_dropped_incomplete_blobs`), so commit time and restore time now agree, and the cost is one full-history rebuild from pi's transcript, which is always correct.

## What changed

- `mergeBlobStore` returns the number of blobs its trim evicted and clears the stored checkpoint whenever that count is non-zero. Putting the check there also covers the merge paths that write no new checkpoint but can still evict blobs an earlier turn's checkpoint references.
- The three commit sites (`commitStoredCheckpoint`, `persistAbortedConversationState`, `commitStoredCheckpointMidPause`) skip installing fresh checkpoint bytes when the merge evicted anything. A mid-pause commit falls back to its metadata-only snapshot.
- New `conversation.checkpoint_dropped_evicted_blobs` debug event.

## Tests

Four cases in `tests/durability.test.ts`: a commit whose blobs the entry bound just evicted drops the checkpoint, a commit whose blob set survived keeps it, a merge that writes no checkpoint drops an earlier one when it evicts, and leaves it alone when it does not.

`bun test` passes (252 tests). `bun run check` is green except for the pre-existing `proto:check` mismatch on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed conversation history replay when checkpointed turns were removed from storage.
  - Checkpoints are now discarded when their referenced conversation data is evicted, preventing silently blank turns.
  - Preserved valid checkpoints when all referenced conversation data remains available.
  - Improved checkpoint handling during paused conversations and storage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->