### PR TITLE
fix: omit legacy model details from run requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fable requests no longer fail with `Connect error not_found`.** The Run request now sends model selection only through `requested_model`; `model_details` is a legacy alternative, and populating both fields made Cursor reject valid `claude-fable-5-1` requests. Fixes [#23](https://github.com/Rahularya01/pi-cursor/issues/23).
+
 ## [1.4.31] - 2026-09-04
 
 ### Changed

--- a/src/stream/request-build.ts
+++ b/src/stream/request-build.ts
@@ -32,7 +32,6 @@ import {
   McpToolResultSchema,
   McpToolResultContentItemSchema,
   McpToolsSchema,
-  ModelDetailsSchema,
   RequestedModelSchema,
   RequestedModel_ModelParameterbytesSchema,
   SelectedContextSchema,
@@ -618,10 +617,10 @@ export function buildCursorRequestFromParts(
   const action = create(ConversationActionSchema, {
     action: { case: "userMessageAction", value: create(UserMessageActionSchema, { userMessage }) },
   });
-  // Send both requestedModel (parameterized variants) and modelDetails (CLI
-  // path still reads the legacy field). Some Cursor models (for example
-  // GPT-5.5) use requestedModel.parameters for context/reasoning/fast instead
-  // of encoding everything in the model ID.
+  // Cursor's current Run path reads requestedModel. Some models use its
+  // parameters for context, reasoning, and fast variants instead of encoding
+  // every option in the model ID. Sending the legacy modelDetails field as
+  // well makes current Cursor reject valid models such as Fable with not_found.
   // Max Mode is routed from model metadata for parameterized variants.
   debugLog("cursor_request.requested_model", {
     modelId,
@@ -633,12 +632,6 @@ export function buildCursorRequestFromParts(
     create(RequestedModel_ModelParameterbytesSchema, parameter),
   );
   const requestedModel = create(RequestedModelSchema, { modelId, maxMode, parameters });
-  const modelDetails = create(ModelDetailsSchema, {
-    modelId,
-    displayModelId: modelId,
-    displayName: modelId,
-    ...(maxMode ? { maxMode: true } : {}),
-  });
   // Do not set customSystemPrompt. Cursor's agent maps that field onto a
   // `--system-prompt` CLI option; this client path rejects it as unknown.
   // Pi's prompt already rides root_prompt_messages_json as a <rules> user
@@ -647,7 +640,6 @@ export function buildCursorRequestFromParts(
   const runRequest = create(AgentRunRequestSchema, {
     conversationState,
     action,
-    modelDetails,
     requestedModel,
     conversationId,
     mcpTools: create(McpToolsSchema, { mcpTools }),

--- a/tests/root-prompt.test.ts
+++ b/tests/root-prompt.test.ts
@@ -132,9 +132,11 @@ describe("request build root prompt wiring", () => {
     const runRequest = fromBinary(AgentClientMessageSchema, pinned.requestBytes).message.value as {
       customSystemPrompt?: string;
       modelDetails?: { modelId?: string };
+      requestedModel?: { modelId?: string };
     };
     expect(runRequest.customSystemPrompt).toBeUndefined();
-    expect(runRequest.modelDetails?.modelId).toBe("cursor-grok-4.6-low");
+    expect(runRequest.modelDetails).toBeUndefined();
+    expect(runRequest.requestedModel?.modelId).toBe("cursor-grok-4.6-low");
   });
 });
 


### PR DESCRIPTION
## Summary

- omit the legacy `model_details` field from `AgentRunRequest`
- keep model selection, parameterized variants, and Max Mode in `requested_model`
- add a wire-serialization regression assertion
- document the Fable regression fix

## Problem

Version `1.4.31` started sending both `model_details` and `requested_model`. Cursor rejects a valid `claude-fable-5-1` request with:

```text
Connect error not_found: Error
```

Changing the client-version header does not affect the failure.

## Verification

Before this change, the live smoke request failed with `not_found`. With this change, the same request returned:

```text
pong
```

Full repository checks pass:

```text
bun run check
259 tests passed
```

Fixes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Fable requests that failed with a `Connect error not_found` response.
  * Requests now use the supported model-selection field, allowing valid `claude-fable-5-1` requests to proceed successfully.
* **Documentation**
  * Added an unreleased changelog entry describing the request compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->