### PR TITLE
fix: refuse empty getBlobResult and stop labeling Connect internal as wire-drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **A missing `getBlobArgs` is no longer answered as an empty blob.** Cursor treats that empty result as valid history, then aborts with Connect `internal: Error`. The provider now refuses the round-trip, invalidates the checkpoint, and fails the generation so the next turn rebuilds from Pi history.
+- **Connect `internal` / `unavailable` / GOAWAY is no longer labeled as wire-drift.** Unknown envelope fields still accumulate on `/cursor.doctor`; they are not stapled onto a transport abort.
+
 ## [1.4.32] - 2026-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - **A missing `getBlobArgs` is no longer answered as an empty blob.** Cursor treats that empty result as valid history, then aborts with Connect `internal: Error`. The provider now refuses the round-trip, invalidates the checkpoint, and fails the generation so the next turn rebuilds from Pi history.
-- **Connect `internal` / `unavailable` / GOAWAY is no longer labeled as wire-drift.** Unknown envelope fields still accumulate on `/cursor.doctor`; they are not stapled onto a transport abort.
+- **Connect `internal` / `unavailable` / `deadline_exceeded` / GOAWAY is no longer labeled as wire-drift.** Unknown envelope fields still accumulate on `/cursor.doctor`; they are not stapled onto a transport abort.
 
 ## [1.4.32] - 2026-09-06
 

--- a/src/stream/native-core.ts
+++ b/src/stream/native-core.ts
@@ -1243,6 +1243,7 @@ function writeNativeStream(
               if (!cancelled && !writer.closed) idleWatchdog.resume();
             });
           },
+          convKey,
         );
         if (progress === "work") {
           if (parkedExecCase !== undefined) {

--- a/src/stream/protocol.ts
+++ b/src/stream/protocol.ts
@@ -48,6 +48,9 @@ export function appendDriftDiagnostic(message: string): string {
   );
 }
 
+const TRANSIENT_CONNECT_RE =
+  /\b(Connect error (?:internal|unavailable|deadline_exceeded)|GOAWAY)\b/i;
+
 export function enhanceCursorStreamError(message: string): string {
   if (isAuthErrorMessage(message)) {
     return (
@@ -58,6 +61,11 @@ export function enhanceCursorStreamError(message: string): string {
   }
   if (isProtocolMismatchMessage(message)) {
     return appendDriftDiagnostic(formatProtocolMismatchHint(message));
+  }
+  // Informational unknown fields accumulate on long sessions. Stapling them onto a
+  // Connect `internal` abort made a transport retry look like a schema mismatch.
+  if (TRANSIENT_CONNECT_RE.test(message)) {
+    return message;
   }
   return appendDriftDiagnostic(message);
 }

--- a/src/stream/server-messages.ts
+++ b/src/stream/server-messages.ts
@@ -261,22 +261,23 @@ function handleKvMessage(
   if (kvCase === "getBlobArgs") {
     const blobId = (kvMsg as any).message.value.blobId;
     const blobIdKey = Buffer.from(blobId).toString("hex");
-    const blobData = blobStore.get(blobIdKey);
-    if (!blobData) {
+    if (!blobStore.has(blobIdKey)) {
       // Cursor only asks for a blob it holds a reference to, so a miss means a
-      // piece of the replayed conversation is gone. The protocol has no way to
-      // say so — an empty result is indistinguishable from an empty blob — and
-      // the turn continues with that history silently blank. Record it so the
-      // amnesia is at least diagnosable from /cursor.doctor and the lifecycle log,
-      // and invalidate the checkpoint so the next turn rebuilds from Pi history.
+      // piece of the replayed conversation is gone. An empty getBlobResult is
+      // indistinguishable from an empty blob, so answering continues the turn
+      // with silent holes and often dies as Connect `internal`. Refuse, drop the
+      // checkpoint, and fail this generation so the next turn rebuilds from Pi.
       lifecycleLog("kv_blob_miss", { blobId: blobIdKey.slice(0, 16), storeSize: blobStore.size });
       setLastStreamEvent("kv_blob_miss");
       markBlobMiss(blobStore);
+      throw new Error(
+        `Cursor asked for blob ${blobIdKey.slice(0, 16)} that is not in the local store (${blobStore.size} entries). Refusing to answer empty.`,
+      );
     }
     sendKvResponse(
       kvMsg,
       "getBlobResult",
-      create(GetBlobResultSchema, blobData ? { blobData } : {}),
+      create(GetBlobResultSchema, { blobData: blobStore.get(blobIdKey) ?? new Uint8Array() }),
       sendFrame,
     );
     return true;

--- a/src/stream/server-messages.ts
+++ b/src/stream/server-messages.ts
@@ -84,6 +84,7 @@ export function processServerMessage(
   onCheckpoint?: (checkpointBytes: Uint8Array) => void,
   onExecUnanswerable?: (execCase: string | undefined) => void,
   onLocalWork?: (work: Promise<void>) => void,
+  convKey?: string,
 ): StreamProgress {
   const msgCase = msg.message.case;
   debugLog("server_message", { msgCase, msg });
@@ -152,7 +153,7 @@ export function processServerMessage(
     return "none";
   }
   if (msgCase === "kvServerMessage") {
-    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame)
+    return handleKvMessage(msg.message.value as KvServerMessage, blobStore, sendFrame, convKey)
       ? "work"
       : "none";
   }
@@ -256,6 +257,7 @@ function handleKvMessage(
   kvMsg: KvServerMessage,
   blobStore: Map<string, Uint8Array>,
   sendFrame: (data: Uint8Array) => void,
+  convKey?: string,
 ): boolean {
   const kvCase = (kvMsg as any).message.case;
   if (kvCase === "getBlobArgs") {
@@ -266,10 +268,15 @@ function handleKvMessage(
       // piece of the replayed conversation is gone. An empty getBlobResult is
       // indistinguishable from an empty blob, so answering continues the turn
       // with silent holes and often dies as Connect `internal`. Refuse, drop the
-      // checkpoint, and fail this generation so the next turn rebuilds from Pi.
-      lifecycleLog("kv_blob_miss", { blobId: blobIdKey.slice(0, 16), storeSize: blobStore.size });
+      // checkpoint by conversation key (the live Map is a clone), and fail this
+      // generation so the next turn rebuilds from Pi.
+      lifecycleLog("kv_blob_miss", {
+        blobId: blobIdKey.slice(0, 16),
+        storeSize: blobStore.size,
+        convKey,
+      });
       setLastStreamEvent("kv_blob_miss");
-      markBlobMiss(blobStore);
+      if (convKey) markBlobMiss(convKey);
       throw new Error(
         `Cursor asked for blob ${blobIdKey.slice(0, 16)} that is not in the local store (${blobStore.size} entries). Refusing to answer empty.`,
       );

--- a/src/stream/session-state.ts
+++ b/src/stream/session-state.ts
@@ -127,18 +127,21 @@ export function rotateConversationAfterRateLimit(stored: StoredConversation): vo
  * A live KV blob miss means Cursor asked for history we no longer hold.
  * Drop the checkpoint and rotate the conversation id so the next turn rebuilds
  * from Pi's transcript instead of replaying holes.
+ *
+ * Identity is the conversation key, not the live blob-store Map. Request build
+ * clones `stored.blobStore`, so comparing Map references misses the journaled
+ * conversation and the next turn replays the same holes.
  */
-export function markBlobMiss(blobStore: Map<string, Uint8Array>): void {
-  for (const [convKey, stored] of conversationStates) {
-    if (stored.blobStore !== blobStore) continue;
-    debugLog("conversation.blob_miss_invalidate", {
-      convKey,
-      hadCheckpoint: !!stored.checkpoint,
-    });
-    clearStoredCheckpoint(stored, false);
-    stored.conversationId = randomUUID();
-    persistJournal(convKey, stored);
-  }
+export function markBlobMiss(convKey: string): void {
+  const stored = getOrHydrateConversation(convKey);
+  if (!stored) return;
+  debugLog("conversation.blob_miss_invalidate", {
+    convKey,
+    hadCheckpoint: !!stored.checkpoint,
+  });
+  clearStoredCheckpoint(stored, false);
+  stored.conversationId = randomUUID();
+  persistJournal(convKey, stored);
 }
 
 /**

--- a/tests/blob-miss.test.ts
+++ b/tests/blob-miss.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { create, fromBinary } from "@bufbuild/protobuf";
 import {
   AgentClientMessageSchema,
@@ -7,7 +7,8 @@ import {
   KvServerMessageSchema,
 } from "../src/proto/agent_pb.js";
 import { processServerMessage } from "../src/stream/server-messages.js";
-import type { StreamState } from "../src/stream/types.js";
+import { conversationStates } from "../src/stream/session-state.js";
+import type { StoredConversation, StreamState } from "../src/stream/types.js";
 
 function emptyState(): StreamState {
   return {
@@ -32,6 +33,10 @@ function getBlobMessage(blobId: Uint8Array) {
     },
   });
 }
+
+afterEach(() => {
+  conversationStates.clear();
+});
 
 describe("getBlobArgs miss must not punch holes", () => {
   it("still returns a blob the store holds", () => {
@@ -76,5 +81,41 @@ describe("getBlobArgs miss must not punch holes", () => {
       ),
     ).toThrow(/blob/i);
     expect(frames).toHaveLength(0);
+  });
+
+  it("drops the stored checkpoint when the live blob store is a clone", () => {
+    const original = new Map<string, Uint8Array>([["aa", new Uint8Array([1])]]);
+    const stored: StoredConversation = {
+      conversationId: "conv-1",
+      checkpoint: new Uint8Array([9, 9, 9]),
+      checkpointSource: "upstream",
+      checkpointTurnCount: 3,
+      sessionScoped: true,
+      blobStore: original,
+      lastAccessMs: Date.now(),
+    };
+    conversationStates.set("conv-key", stored);
+    // request-build.ts clones stored.blobStore; the live stream does not share that Map.
+    const live = new Map(original);
+    const frames: Uint8Array[] = [];
+
+    expect(() =>
+      processServerMessage(
+        getBlobMessage(new Uint8Array([0xe3, 0x49])),
+        live,
+        [],
+        (frame) => frames.push(frame),
+        emptyState(),
+        () => {},
+        () => {},
+        undefined,
+        undefined,
+        undefined,
+        "conv-key",
+      ),
+    ).toThrow(/blob/i);
+    expect(frames).toHaveLength(0);
+    expect(stored.checkpoint).toBeNull();
+    expect(stored.conversationId).not.toBe("conv-1");
   });
 });

--- a/tests/blob-miss.test.ts
+++ b/tests/blob-miss.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { create, fromBinary } from "@bufbuild/protobuf";
+import {
+  AgentClientMessageSchema,
+  AgentServerMessageSchema,
+  GetBlobArgsSchema,
+  KvServerMessageSchema,
+} from "../src/proto/agent_pb.js";
+import { processServerMessage } from "../src/stream/server-messages.js";
+import type { StreamState } from "../src/stream/types.js";
+
+function emptyState(): StreamState {
+  return {
+    toolCallIndex: 0,
+    pendingExecs: [],
+    outputTokens: 0,
+    totalTokens: 0,
+    turnEnded: false,
+  };
+}
+
+function getBlobMessage(blobId: Uint8Array) {
+  return create(AgentServerMessageSchema, {
+    message: {
+      case: "kvServerMessage",
+      value: create(KvServerMessageSchema, {
+        message: {
+          case: "getBlobArgs",
+          value: create(GetBlobArgsSchema, { blobId }),
+        },
+      }),
+    },
+  });
+}
+
+describe("getBlobArgs miss must not punch holes", () => {
+  it("still returns a blob the store holds", () => {
+    const blobId = new Uint8Array([0xab, 0xcd]);
+    const blobData = new Uint8Array([1, 2, 3]);
+    const store = new Map<string, Uint8Array>([[Buffer.from(blobId).toString("hex"), blobData]]);
+    const frames: Uint8Array[] = [];
+
+    expect(
+      processServerMessage(
+        getBlobMessage(blobId),
+        store,
+        [],
+        (frame) => frames.push(frame),
+        emptyState(),
+        () => {},
+        () => {},
+      ),
+    ).toBe("work");
+    expect(frames).toHaveLength(1);
+    const answer = fromBinary(AgentClientMessageSchema, frames[0]!.subarray(5));
+    expect(answer.message.case).toBe("kvClientMessage");
+    const kv = answer.message.value as {
+      message: { case: string; value: { blobData?: Uint8Array } };
+    };
+    expect(kv.message.case).toBe("getBlobResult");
+    expect(Buffer.from(kv.message.value.blobData ?? [])).toEqual(Buffer.from(blobData));
+  });
+
+  it("does not answer a missing blob with an empty getBlobResult", () => {
+    const frames: Uint8Array[] = [];
+
+    expect(() =>
+      processServerMessage(
+        getBlobMessage(new Uint8Array([0xe3, 0x49, 0xbe, 0xb7])),
+        new Map(),
+        [],
+        (frame) => frames.push(frame),
+        emptyState(),
+        () => {},
+        () => {},
+      ),
+    ).toThrow(/blob/i);
+    expect(frames).toHaveLength(0);
+  });
+});

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -103,12 +103,17 @@ describe("drift reporting in stream errors", () => {
     expect(message).not.toContain("wire-drift");
   });
 
-  it("does not staple wire-drift onto a Connect internal abort", () => {
+  it.each([
+    "Connect error internal: Error",
+    "Connect error unavailable",
+    "Connect error deadline_exceeded",
+    "GOAWAY",
+  ])("does not staple wire-drift onto %s", (raw) => {
     recordDriftSignal("unknown_fields", "conversationCheckpointUpdate.payload#37");
     recordDriftSignal("server_message", "unknown");
-    const message = enhanceCursorStreamError("Connect error internal: Error");
+    const message = enhanceCursorStreamError(raw);
 
-    expect(message).toBe("Connect error internal: Error");
+    expect(message).toBe(raw);
     expect(message).not.toContain("wire-drift");
   });
 });

--- a/tests/drift.test.ts
+++ b/tests/drift.test.ts
@@ -102,4 +102,13 @@ describe("drift reporting in stream errors", () => {
     expect(message).toContain("auth-hint");
     expect(message).not.toContain("wire-drift");
   });
+
+  it("does not staple wire-drift onto a Connect internal abort", () => {
+    recordDriftSignal("unknown_fields", "conversationCheckpointUpdate.payload#37");
+    recordDriftSignal("server_message", "unknown");
+    const message = enhanceCursorStreamError("Connect error internal: Error");
+
+    expect(message).toBe("Connect error internal: Error");
+    expect(message).not.toContain("wire-drift");
+  });
 });


### PR DESCRIPTION
Fixes #26.

## Summary

A long Cursor session can ask for a blob this process no longer holds (`kv_blob_miss`). The provider answered with an empty `getBlobResult`. Cursor treated that as valid history and aborted with `Connect error internal: Error`. Unknown envelope fields accumulated on the same process were then stapled onto that abort as `[wire-drift: …]`, so `/cursor.doctor` told people to regenerate proto / bump `PI_CURSOR_CLIENT_VERSION`.

That diagnosis is wrong. The unknown fields are noise. The hole in history is the cause.

## Changes

- Missing `getBlobArgs`: log, drop the **stored** checkpoint by conversation key (the live blob store is a clone), throw. Do not answer empty.
- Connect `internal` / `unavailable` / `deadline_exceeded` / GOAWAY: leave the transport error alone. Drift stays on `/cursor.doctor`.

## Tests

- `tests/blob-miss.test.ts`: present blob still returns data; missing blob does not send `getBlobResult`; cloned live store still invalidates the journaled checkpoint.
- `tests/drift.test.ts`: Connect `internal` / `unavailable` / `deadline_exceeded` / GOAWAY are not rewritten as wire-drift even when unknown fields are on record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Missing conversation history data now fails safely instead of being treated as valid empty content, allowing the next turn to rebuild correctly.
  - Transient connection errors, including timeouts and GOAWAY events, are no longer mislabeled as protocol or schema drift.
  - Tool continuations after stale checkpoints now recover and resume from the current conversation history.

- **Tests**
  - Added coverage for missing history data, checkpoint recovery, and transient connection error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->