### PR TITLE
fix: rebuild tool continuation from in-flight turn after stale checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tool continuation after a stale checkpoint no longer dies with `skipReason=stale_checkpoint`.** `discardStaleCheckpointIfNeeded` clears mid-pause metadata along with the checkpoint, and a `synthesized_after_idle` rebuild keys the next pause to rewritten wire history. Rebuild then required that snapshot and hard-skipped even when Pi's in-flight tool ids matched the results. Full-history rebuild now pins to the current request's in-flight turn; a matching mid-pause snapshot is still required to cover parked execs when it is present.
+
 ## [1.4.32] - 2026-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **Tool continuation after a stale checkpoint no longer dies with `skipReason=stale_checkpoint`.** `discardStaleCheckpointIfNeeded` clears mid-pause metadata along with the checkpoint, and a `synthesized_after_idle` rebuild keys the next pause to rewritten wire history. Rebuild then required that snapshot and hard-skipped even when Pi's in-flight tool ids matched the results. Full-history rebuild now pins to the current request's in-flight turn; a matching mid-pause snapshot is still required to cover parked execs when it is present.
+- **Tool continuation after a stale checkpoint no longer dies with `skipReason=stale_checkpoint`.** `discardStaleCheckpointIfNeeded` clears mid-pause metadata along with the checkpoint, and a `synthesized_after_idle` rebuild keys the next pause to rewritten wire history. Rebuild then required that snapshot and hard-skipped even when Pi's in-flight tool ids matched the results. Full-history rebuild now pins to the current request's in-flight turn when the snapshot was wiped. A recorded pending-exec list is still required to be covered, even if its fingerprint no longer matches.
 
 ## [1.4.32] - 2026-09-06
 

--- a/src/stream/recovery.ts
+++ b/src/stream/recovery.ts
@@ -343,40 +343,28 @@ export function validatePendingCoveredByReceived(
   return { ok: true };
 }
 
+function midPauseSnapshotMatchesRequest(
+  stored: StoredConversation,
+  completedTurns: ParsedTurn[],
+  nowMs: number,
+  maxAgeMs: number,
+): boolean {
+  if (!stored.midPausePendingToolCalls?.length) return false;
+  if (stored.midPauseTurnCount !== completedTurns.length) return false;
+  const currentHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
+  if (stored.midPauseHistoryFingerprint !== currentHistoryFingerprint) return false;
+  const recordedAtMs = stored.midPauseRecordedAtMs;
+  if (recordedAtMs === undefined || nowMs - recordedAtMs > maxAgeMs) return false;
+  return true;
+}
+
 export function planFullHistoryRebuild(
   input: PlanRecoveryInput & { stored: StoredConversation },
   hadStoredCheckpoint: boolean,
   rebuildReason: FullHistoryRebuildReason,
 ): RecoveryDecision {
-  const pendingToolCalls = input.stored.midPausePendingToolCalls;
-  if (!pendingToolCalls?.length) {
-    return skipRecovery("no_midpause_snapshot", hadStoredCheckpoint);
-  }
-
   if (input.stored.sessionScoped && input.stored.sessionId !== input.sessionId) {
     return skipRecovery("session_mismatch", hadStoredCheckpoint);
-  }
-
-  const currentTurnCount = input.completedTurns.length;
-  if (input.stored.midPauseTurnCount !== currentTurnCount) {
-    clearStoredMidPauseMetadata(input.stored);
-    return skipRecovery("midpause_turn_count_mismatch", hadStoredCheckpoint);
-  }
-
-  const currentHistoryFingerprint = fingerprintCompletedTurns(input.completedTurns);
-  if (input.stored.midPauseHistoryFingerprint !== currentHistoryFingerprint) {
-    clearStoredMidPauseMetadata(input.stored);
-    return skipRecovery("midpause_history_fingerprint_mismatch", hadStoredCheckpoint);
-  }
-
-  const recordedAtMs = input.stored.midPauseRecordedAtMs;
-  const maxAgeMs =
-    input.midPauseRebuildMaxAgeMs ??
-    resolveMidPauseRebuildMaxAgeMs(process.env.PI_CURSOR_MIDPAUSE_REBUILD_MAX_AGE_MS);
-  const now = input.nowMs ?? Date.now();
-  if (recordedAtMs === undefined || now - recordedAtMs > maxAgeMs) {
-    clearStoredMidPauseMetadata(input.stored);
-    return skipRecovery("midpause_metadata_stale", hadStoredCheckpoint);
   }
 
   const strippedInFlightTurn = input.inFlightTurn
@@ -391,18 +379,8 @@ export function planFullHistoryRebuild(
     return skipRecovery("no_inflight_tool_continuation", hadStoredCheckpoint);
   }
 
-  const pendingIds = pendingToolCalls.map((c) => c.toolCallId).filter(identifiableToolCallId);
   const receivedIds = input.toolResults.map((r) => r.toolCallId).filter(identifiableToolCallId);
-  const pendingVsReceived = validatePendingCoveredByReceived(pendingIds, receivedIds);
   const inFlightVsReceived = validateExactToolResultMatch(inFlightToolCallIds, receivedIds);
-  if (!pendingVsReceived.ok) {
-    return skipRecovery(
-      "pending_tool_call_mismatch",
-      hadStoredCheckpoint,
-      pendingVsReceived.expected,
-      pendingVsReceived.received,
-    );
-  }
   if (!inFlightVsReceived.ok) {
     return skipRecovery(
       "pending_tool_call_mismatch",
@@ -410,6 +388,30 @@ export function planFullHistoryRebuild(
       inFlightVsReceived.expected,
       inFlightVsReceived.received,
     );
+  }
+
+  // A matching mid-pause snapshot still has to be covered by the results. A missing,
+  // rewritten, or discarded snapshot must not block rebuild: discardStaleCheckpoint
+  // clears mid-pause along with the checkpoint, and synthesized_after_idle keys the
+  // snapshot to wire history that no longer fingerprints as Pi's completedTurns.
+  // The current request's in-flight turn is the pin.
+  const maxAgeMs =
+    input.midPauseRebuildMaxAgeMs ??
+    resolveMidPauseRebuildMaxAgeMs(process.env.PI_CURSOR_MIDPAUSE_REBUILD_MAX_AGE_MS);
+  const now = input.nowMs ?? Date.now();
+  if (midPauseSnapshotMatchesRequest(input.stored, input.completedTurns, now, maxAgeMs)) {
+    const pendingIds = (input.stored.midPausePendingToolCalls ?? [])
+      .map((c) => c.toolCallId)
+      .filter(identifiableToolCallId);
+    const pendingVsReceived = validatePendingCoveredByReceived(pendingIds, receivedIds);
+    if (!pendingVsReceived.ok) {
+      return skipRecovery(
+        "pending_tool_call_mismatch",
+        hadStoredCheckpoint,
+        pendingVsReceived.expected,
+        pendingVsReceived.received,
+      );
+    }
   }
 
   return {
@@ -458,10 +460,7 @@ export function planRecovery(input: PlanRecoveryInput): RecoveryDecision {
   );
 
   if (!input.stored.checkpoint) {
-    // Prefer rebuild over hard fail when mid-pause metadata is still trustworthy.
-    const rebuilt = tryRebuild("stale_checkpoint");
-    if (rebuilt.kind !== "skip") return rebuilt;
-    return skipRecovery("stale_checkpoint", hadStoredCheckpointPreDiscard);
+    return tryRebuild("stale_checkpoint");
   }
 
   const expected = (input.stored.midPausePendingToolCalls ?? [])

--- a/src/stream/recovery.ts
+++ b/src/stream/recovery.ts
@@ -343,21 +343,6 @@ export function validatePendingCoveredByReceived(
   return { ok: true };
 }
 
-function midPauseSnapshotMatchesRequest(
-  stored: StoredConversation,
-  completedTurns: ParsedTurn[],
-  nowMs: number,
-  maxAgeMs: number,
-): boolean {
-  if (!stored.midPausePendingToolCalls?.length) return false;
-  if (stored.midPauseTurnCount !== completedTurns.length) return false;
-  const currentHistoryFingerprint = fingerprintCompletedTurns(completedTurns);
-  if (stored.midPauseHistoryFingerprint !== currentHistoryFingerprint) return false;
-  const recordedAtMs = stored.midPauseRecordedAtMs;
-  if (recordedAtMs === undefined || nowMs - recordedAtMs > maxAgeMs) return false;
-  return true;
-}
-
 export function planFullHistoryRebuild(
   input: PlanRecoveryInput & { stored: StoredConversation },
   hadStoredCheckpoint: boolean,
@@ -390,19 +375,14 @@ export function planFullHistoryRebuild(
     );
   }
 
-  // A matching mid-pause snapshot still has to be covered by the results. A missing,
-  // rewritten, or discarded snapshot must not block rebuild: discardStaleCheckpoint
-  // clears mid-pause along with the checkpoint, and synthesized_after_idle keys the
-  // snapshot to wire history that no longer fingerprints as Pi's completedTurns.
-  // The current request's in-flight turn is the pin.
-  const maxAgeMs =
-    input.midPauseRebuildMaxAgeMs ??
-    resolveMidPauseRebuildMaxAgeMs(process.env.PI_CURSOR_MIDPAUSE_REBUILD_MAX_AGE_MS);
-  const now = input.nowMs ?? Date.now();
-  if (midPauseSnapshotMatchesRequest(input.stored, input.completedTurns, now, maxAgeMs)) {
-    const pendingIds = (input.stored.midPausePendingToolCalls ?? [])
-      .map((c) => c.toolCallId)
-      .filter(identifiableToolCallId);
+  // Recorded pending execs must still be covered, even when fingerprint / turn
+  // count / age no longer match Pi's completedTurns (synthesized_after_idle).
+  // Only a wiped snapshot (discardStaleCheckpoint) has no pending list; then
+  // the request's in-flight turn is the pin.
+  const pendingIds = (input.stored.midPausePendingToolCalls ?? [])
+    .map((c) => c.toolCallId)
+    .filter(identifiableToolCallId);
+  if (pendingIds.length > 0) {
     const pendingVsReceived = validatePendingCoveredByReceived(pendingIds, receivedIds);
     if (!pendingVsReceived.ok) {
       return skipRecovery(

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -193,9 +193,9 @@ describe("planRecovery", () => {
       convKey: "c1",
     });
 
-    expect(decision.kind).toBe("skip");
-    if (decision.kind === "skip") {
-      expect(decision.reason).toBe("pending_tool_call_mismatch");
+    expect(decision.kind).toBe("rebuild_full_history");
+    if (decision.kind === "rebuild_full_history") {
+      expect(decision.rebuildReason).toBe("checkpoint_tool_mismatch");
     }
   });
 
@@ -205,6 +205,66 @@ describe("planRecovery", () => {
       checkpoint: new Uint8Array([9]),
       midPauseTurnCount: completedTurns.length,
       midPauseHistoryFingerprint: fingerprintCompletedTurns(completedTurns),
+    });
+    const decision = planRecovery({
+      stored,
+      toolResults: [{ toolCallId: "t1", content: "ok" }],
+      completedTurns,
+      inFlightTurn: toolTurn(["t1"]),
+      requestId: "r1",
+      convKey: "c1",
+      discardStaleCheckpoint: (s) => {
+        s.checkpoint = null;
+      },
+    });
+    expect(decision.kind).toBe("rebuild_full_history");
+    if (decision.kind === "rebuild_full_history") {
+      expect(decision.rebuildReason).toBe("stale_checkpoint");
+    }
+  });
+
+  it("rebuilds from the in-flight turn when stale discard also wiped mid-pause", () => {
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const stored = storedBase({
+      checkpoint: new Uint8Array([9]),
+      midPauseTurnCount: completedTurns.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(completedTurns),
+    });
+    const decision = planRecovery({
+      stored,
+      toolResults: [{ toolCallId: "t1", content: "ok" }],
+      completedTurns,
+      inFlightTurn: toolTurn(["t1"]),
+      requestId: "r1",
+      convKey: "c1",
+      discardStaleCheckpoint: (s) => {
+        s.checkpoint = null;
+        delete s.midPausePendingToolCalls;
+        delete s.midPauseTurnCount;
+        delete s.midPauseHistoryFingerprint;
+        delete s.midPauseRecordedAtMs;
+      },
+    });
+    expect(decision.kind).toBe("rebuild_full_history");
+    if (decision.kind === "rebuild_full_history") {
+      expect(decision.rebuildReason).toBe("stale_checkpoint");
+    }
+  });
+
+  it("rebuilds from the in-flight turn when mid-pause fingerprints rewritten wire history", () => {
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const rewritten: ParsedTurn[] = [
+      ...completedTurns,
+      {
+        userText: "do work",
+        steps: [{ kind: "toolCall", toolCallId: "t1", toolName: "read", arguments: {} }],
+      },
+    ];
+    const stored = storedBase({
+      checkpoint: new Uint8Array([9]),
+      midPausePendingToolCalls: [{ toolCallId: "t1", toolName: "read" }],
+      midPauseTurnCount: rewritten.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(rewritten),
     });
     const decision = planRecovery({
       stored,

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -283,6 +283,41 @@ describe("planRecovery", () => {
     }
   });
 
+  it("still requires recorded pending execs even when mid-pause fingerprints rewritten history", () => {
+    const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
+    const rewritten: ParsedTurn[] = [
+      ...completedTurns,
+      {
+        userText: "do work",
+        steps: [{ kind: "toolCall", toolCallId: "t1", toolName: "read", arguments: {} }],
+      },
+    ];
+    const stored = storedBase({
+      checkpoint: new Uint8Array([9]),
+      midPausePendingToolCalls: [
+        { toolCallId: "t1", toolName: "read" },
+        { toolCallId: "t2", toolName: "read" },
+      ],
+      midPauseTurnCount: rewritten.length,
+      midPauseHistoryFingerprint: fingerprintCompletedTurns(rewritten),
+    });
+    const decision = planRecovery({
+      stored,
+      toolResults: [{ toolCallId: "t1", content: "ok" }],
+      completedTurns,
+      inFlightTurn: toolTurn(["t1"]),
+      requestId: "r1",
+      convKey: "c1",
+      discardStaleCheckpoint: (s) => {
+        s.checkpoint = null;
+      },
+    });
+    expect(decision.kind).toBe("skip");
+    if (decision.kind === "skip") {
+      expect(decision.reason).toBe("pending_tool_call_mismatch");
+    }
+  });
+
   it("falls back to rebuild when checkpoint tool ids mismatch but mid-pause is valid", () => {
     const completedTurns: ParsedTurn[] = [{ userText: "earlier", steps: [] }];
     const stored = storedBase({


### PR DESCRIPTION
## Summary

A mid-tool bridge loss could still die with `skipReason=stale_checkpoint` even when Pi's in-flight tool ids matched the results.

`discardStaleCheckpointIfNeeded` clears mid-pause metadata along with the checkpoint. A `synthesized_after_idle` rebuild then keys the next pause to rewritten wire history, so the snapshot no longer fingerprints as Pi's completedTurns. Rebuild required that snapshot and hard-skipped.

## Changes

- Full-history rebuild pins to the current request's in-flight turn when tool ids exact-match the results.
- A matching mid-pause snapshot is still required to cover parked execs when it is present (parked exec with no result still skips).
- Do not resume into an existing checkpoint without a mid-pause snapshot; rebuild from Pi history instead.

## Tests

- Stale discard that also wipes mid-pause now rebuilds.
- Mid-pause fingerprinted against rewritten wire history now rebuilds.
- Checkpoint without mid-pause no longer resumes into those bytes.

`bun test`: 261 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after stale or cleared checkpoints during tool continuations.
  - Full-history recovery now follows the active in-flight request, even when conversation history has been rewritten or checkpoint metadata is missing.
  - Pending tool executions remain covered despite outdated checkpoint details.
  - Recovery continues to skip cases where recorded tool calls do not match the returned results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->